### PR TITLE
Adds google analytics and ga id to application config

### DIFF
--- a/app/views/layouts/_ga.html.erb
+++ b/app/views/layouts/_ga.html.erb
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', '<%= APPLICATION_CONFIG["ga_id"] %>', 'auto');
+ga('send', 'pageview');
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,4 +27,5 @@
   </body>
   <%# Include the javascript at the bottom to ensure it loads last when the page is ready %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+  <%= render partial: "layouts/ga" %>
 </html>

--- a/config/application_config.example.yml.erb
+++ b/config/application_config.example.yml.erb
@@ -11,6 +11,8 @@ cell_types:
   - 'Another Cell Type'
   - 'A Third Cell Type'
 
+ga_id: UA-35760875-18
+
 # Configurations for image file uploads
 file_upload:
   # Sub-directory that is http enabled, typically beneath /public for this app


### PR DESCRIPTION
Fixes #5

Currently google analytics is looking at the url "http://test.library.oregonstate.edu" for testing purposes. Once we get closer to a live staging/production server we can swap the url over in google.