### PR TITLE
add basic UI for classroom schedule

### DIFF
--- a/app/assets/javascripts/react/actions/touchActions.js
+++ b/app/assets/javascripts/react/actions/touchActions.js
@@ -91,10 +91,10 @@ export const fetchHours = (url, dates) => {
         'Accept': 'application/vnd.kiosks.v1',
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({dates:[...dates]})
+      body: JSON.stringify({dates: [...dates]})
     })
       .then(response => {
-        switch(response.status) {
+        switch (response.status) {
           case 200:
             return response.json();
           case 404:
@@ -113,6 +113,131 @@ export const fetchHours = (url, dates) => {
       .catch(err => {
         dispatch(addError({message: err.message, code: err.code}));
         dispatch(fetchedHours());
+      });
+  };
+};
+
+export const SET_CLASSROOM_SCHEDULE = 'SET_CLASSROOM_SCHEDULE';
+export const setClassroomSchedule = (classroom_schedule, date) => {
+  return {
+    type: SET_CLASSROOM_SCHEDULE,
+    data: {
+      classroom_schedule, date
+    }
+  };
+};
+
+export const FETCHING_CLASSROOM_SCHEDULE = 'FETCHING_CLASSROOM_SCHEDULE';
+export const fetchingClassroomSchedule = () => {
+  return {
+    type: FETCHING_CLASSROOM_SCHEDULE
+  };
+};
+
+export const FETCHED_CLASSROOM_SCHEDULE = 'FETCHED_CLASSROOM_SCHEDULE';
+export const fetchedClassroomSchedule = () => {
+  return {
+    type: FETCHED_CLASSROOM_SCHEDULE
+  };
+};
+
+export const fetchClassroomSchedule = (url, date) => {
+  return (dispatch) => {
+    dispatch(fetchingClassroomSchedule());
+    // Default to today
+    if (!date) {
+      date = moment();
+    }
+    let parsed_date = moment(date).format("YYYYMMDD");
+    return fetch(`${url.replace("{date}", parsed_date)}`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/vnd.kiosks.v1',
+        'Content-Type': 'application/json'
+      }
+    })
+      .then(response => {
+        switch (response.status) {
+          case 200:
+            return response.json();
+          case 404:
+            return {"error": "Classroom schedule not found for the selected date."};
+          default:
+            return {"error": "Error fetching classroom schedule, please notify the help desk."};
+        }
+      })
+      .then(json => {
+        dispatch(setClassroomSchedule(json, parsed_date));
+        // it's fast, so let the fetching_classroom_schedule animation run for 800ms more. ;)
+        setTimeout(() => {
+          dispatch(fetchedClassroomSchedule());
+        }, 800);
+      })
+      .catch(err => {
+        dispatch(addError({message: err.message, code: err.code}));
+        dispatch(fetchedClassroomSchedule());
+      });
+  };
+};
+
+export const TOGGLE_CLASSROOM_SELECTED = 'TOGGLE_CLASSROOM_SELECTED';
+export const toggleClassroomSelected = (shortname, selected) => {
+  return {
+    type: TOGGLE_CLASSROOM_SELECTED,
+    data: {shortname, selected: selected}
+  };
+};
+
+export const FETCHING_CLASSROOMS = 'FETCHING_CLASSROOMS';
+export const fetchingClassrooms = () => {
+  return {
+    type: FETCHING_CLASSROOMS
+  };
+};
+export const FETCHED_CLASSROOMS = 'FETCHED_CLASSROOMS';
+export const fetchedClassrooms = (classrooms) => {
+  return {
+    type: FETCHED_CLASSROOMS,
+    classrooms
+  };
+};
+
+export const fetchClassrooms = (url) => {
+  return (dispatch) => {
+    dispatch(fetchingClassrooms());
+    return fetch(url, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/vnd.kiosks.v1',
+        'Content-Type': 'application/json'
+      }
+    })
+      .then(response => {
+        switch (response.status) {
+          case 200:
+            return response.json();
+          case 404:
+            return {"error": "Classrooms not found."};
+          default:
+            return {"error": "Error fetching classrooms, please notify the help desk."};
+        }
+      })
+      .then(json => {
+        // array reduce to translate from an array to an object map while
+        // adding "selected" field to each of the classrooms for the purpose of the UI
+        // to track which classrooms are selected.
+        const classrooms = json.reduce((accumulator, current, index) => {
+          accumulator[current.shortname] = Object.assign({}, current, {selected: true});
+          return accumulator;
+        }, {});
+        // it's fast, so let the fetching_classrooms animation run for 800ms more. ;)
+        setTimeout(() => {
+          dispatch(fetchedClassrooms(classrooms));
+        }, 800);
+      })
+      .catch(err => {
+        dispatch(addError({message: err.message, code: err.code}));
+        dispatch(fetchedClassrooms([]));
       });
   };
 };

--- a/app/assets/javascripts/react/components/TouchClassroomSchedule.js
+++ b/app/assets/javascripts/react/components/TouchClassroomSchedule.js
@@ -1,21 +1,16 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import Kiosk from './presentational/Touch/Kiosk';
+import ClassroomSchedule from './presentational/Touch/ClassroomSchedule';
 import * as actions from '../actions';
 
 // Top level mapping of the application state to properties of component that is being
 // connected.
 const mapStateToProps = (state) => {
   return {
-    slides: state.kiosk.slides,
-    maps: state.touch.maps,
-    url: state.kiosk.url,
-    api: state.kiosk.api,
-    hours: state.touch.hours,
-    classroom_schedule: state.touch.classroom_schedule,
-    is_fetching_slides: state.touch.is_fetching_slides,
-    is_fetching_hours: state.touch.is_fetching_hours,
+    classrooms: state.touch.classrooms,
+    is_fetching_classrooms: state.touch.is_fetching_classrooms,
+    is_fetching_classroom_schedule: state.touch.is_fetching_classroom_schedule
   }
 };
 
@@ -25,4 +20,4 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 // Connect the mappings (state -> properties, and actions -> dispatch) to the application component
-export default connect(mapStateToProps, mapDispatchToProps)(Kiosk);
+export default connect(mapStateToProps, mapDispatchToProps)(ClassroomSchedule);

--- a/app/assets/javascripts/react/components/TouchClassroomScheduleDay.js
+++ b/app/assets/javascripts/react/components/TouchClassroomScheduleDay.js
@@ -1,21 +1,17 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import Kiosk from './presentational/Touch/Kiosk';
+import ClassroomScheduleDay from './presentational/Touch/ClassroomScheduleDay';
 import * as actions from '../actions';
 
 // Top level mapping of the application state to properties of component that is being
 // connected.
 const mapStateToProps = (state) => {
   return {
-    slides: state.kiosk.slides,
-    maps: state.touch.maps,
-    url: state.kiosk.url,
-    api: state.kiosk.api,
-    hours: state.touch.hours,
+    date: state.touch.date,
+    classrooms: state.touch.classrooms,
     classroom_schedule: state.touch.classroom_schedule,
-    is_fetching_slides: state.touch.is_fetching_slides,
-    is_fetching_hours: state.touch.is_fetching_hours,
+    is_fetching_classroom_schedule: state.touch.is_fetching_classroom_schedule
   }
 };
 
@@ -25,4 +21,4 @@ const mapDispatchToProps = (dispatch) => {
 };
 
 // Connect the mappings (state -> properties, and actions -> dispatch) to the application component
-export default connect(mapStateToProps, mapDispatchToProps)(Kiosk);
+export default connect(mapStateToProps, mapDispatchToProps)(ClassroomScheduleDay);

--- a/app/assets/javascripts/react/components/presentational/Touch/ClassroomSchedule.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/ClassroomSchedule.js
@@ -1,0 +1,160 @@
+import React, {Component, PropTypes} from 'react';
+import Calendar from 'rc-calendar';
+import DatePicker from 'rc-calendar/lib/Picker';
+import moment from 'moment';
+import ConnectedClassroomScheduleDay from '../../TouchClassroomScheduleDay';
+
+export const now = moment();
+export const default_calendar_value = now.clone();
+
+class ClassroomSchedule extends Component {
+  /**
+   * Initialize a classroom schedule UI and set the initial state to display "today"
+   * @param props - the properties passed into the component
+   */
+  constructor(props) {
+    super(props);
+    this.state = {selected_date: now};
+  }
+
+  /**
+   * Automatically hide the classroom schedule after a period of inactivity
+   */
+  setHideTimeout() {
+    const hide = () => {
+      this.props.setModalRootComponent(undefined);
+      this.props.setModalVisibility(false);
+    };
+    this.hide_timeout = setTimeout(hide, 120000);
+  }
+
+  /**
+   * When the classroom filter element is clicked, fire off an action to propagate the change through the app state
+   * @param {Object} classroom - the classroom which was clicked
+   */
+  classroomClicked(classroom) {
+    this.props.toggleClassroomSelected(classroom.shortname, classroom.selected);
+  }
+
+  /**
+   * When a date on the calendar is clicked, fetch the schedule for that day and reset the hide timeout
+   * @param {Moment} date - the date clicked
+   */
+  dateClicked(date) {
+    this.setState({selected_date: date});
+    this.props.fetchClassroomSchedule(this.props.api.classroom_schedule, date);
+    clearTimeout(this.hide_timeout);
+    this.setHideTimeout();
+  }
+
+  /**
+   * After the component has mounted, fetch the classroom list and the current days schedule
+   */
+  componentDidMount() {
+    this.props.fetchClassrooms(this.props.api.classrooms);
+    this.props.fetchClassroomSchedule(this.props.api.classroom_schedule, now);
+    this.setHideTimeout();
+  }
+
+  /**
+   * As the component is unmounting, clear the hide timeout
+   */
+  componentWillUnmount() {
+    clearTimeout(this.hide_timeout);
+  }
+
+  /**
+   * Sort the list of classrooms by their keys
+   * @returns {Array} - sorted list of classrooms
+   * @private
+   */
+  _sortedClassrooms() {
+    const ordered = [];
+    Object.keys(this.props.classrooms).sort().forEach((k) => ordered.push(this.props.classrooms[k]));
+    return ordered;
+  }
+
+  /**
+   * Includes Bootstrap elements for mobile and regular displays using hidden-*  and col-* semantics
+   * @returns {JSX} - the rendered UI
+   */
+  render() {
+    const calendar = (<Calendar defaultValue={default_calendar_value}
+                                onChange={this.dateClicked.bind(this)}
+                                showDateInput={false}/>);
+    const is_fetching_class = this.props.is_fetching_classroom_schedule ? "is_fetching" : "";
+    const date = this.state.selected_date.format('dddd, MMMM Do, YYYY');
+    const classrooms = this._sortedClassrooms();
+    return (
+      <div id="classroom_schedule" className="panel panel-default">
+        <div className="panel-heading">
+          <span className="panel-title">Library Classrooms Schedule</span>
+          <span className={`glyphicon glyphicon-repeat ${is_fetching_class}`} aria-hidden="true">&nbsp;</span>
+        </div>
+        <div className="container-fluid classroom-schedule-table-container">
+          <div className="row">
+            <h2>{date}</h2>
+            <div className="classroom-schedule-table-datepicker hidden-md hidden-lg col-sm-12">
+              <DatePicker calendar={calendar}
+                          animation="slide-down"
+                          defaultValue={default_calendar_value}
+                          onChange={this.dateClicked.bind(this)}
+                          showDateInput={false}>
+                {({value}) => {
+                  return (
+                    <span tabIndex="0">
+                      <label htmlFor="classroom_schedule_date_picker">Select a Date:</label>
+                      <input id="classroom_schedule_date_picker"
+                             placeholder="Select a date."
+                             style={{width: 250}}
+                             readOnly
+                             tabIndex="-1"
+                             className="ant-calendar-picker-input ant-input"
+                             value={value && value.format('YYYY-MM-DD') || ''}/>
+                    </span>
+                  );
+                }}
+              </DatePicker>
+            </div>
+            <div className="hidden-sm hidden-xs col-md-9 classroom-filter">
+              <ul>
+                <li key="filter.classroom_schedule" >Filter Schedule:</li>
+                {classrooms.map((classroom) => {
+                  return (
+                    <li key={classroom.shortname}
+                        className={`${classroom.shortname} ${classroom.selected ? "selected" : ""}`}
+                        data-shortname={classroom.shortname}
+                        data-selected={classroom.selected}
+                        onClick={this.classroomClicked.bind(this, classroom)}>
+                      <span className={`glyphicon glyphicon-ok-sign ${classroom.selected ? "checked" : ""}`}
+                            aria-hidden="true">
+                        &nbsp;
+                      </span>
+                      {classroom.title}
+                    </li>);
+                })}
+              </ul>
+            </div>
+            <div className="col-md-9 col-sm-12">
+              <ConnectedClassroomScheduleDay />
+            </div>
+            <div className="hidden-sm hidden-xs col-md-3">{calendar}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ClassroomSchedule.propTypes = {
+  classroom_schedule: PropTypes.object.isRequired,
+  classrooms: PropTypes.object.isRequired,
+  api: PropTypes.object.isRequired,
+  is_fetching_classroom_schedule: PropTypes.bool.isRequired,
+  is_fetching_classrooms: PropTypes.bool.isRequired,
+  fetchClassroomSchedule: PropTypes.func.isRequired,
+  fetchClassrooms: PropTypes.func.isRequired,
+  toggleClassroomSelected: PropTypes.func.isRequired,
+};
+
+export default ClassroomSchedule;

--- a/app/assets/javascripts/react/components/presentational/Touch/ClassroomScheduleDay.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/ClassroomScheduleDay.js
@@ -1,0 +1,159 @@
+import React, {Component, PropTypes} from 'react';
+import moment from 'moment';
+
+/**
+ * the valid hours in which classrooms are available for
+ * @type {number[]}
+ */
+const CLASSROOM_HOURS = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23];
+
+class ClassroomScheduleDay extends Component {
+  /**
+   * Determine if the provided time is within the start_time and end_time
+   * @param {Moment} start_time - the events start time
+   * @param {Moment} end_time - the events end time
+   * @param {Moment} this_time - the specific time to check
+   * @returns {boolean|*} - true if this_time is >= start_time and < end_time
+   * @private
+   */
+  _eventIncludesTime(start_time, end_time, this_time) {
+    // current 15 minute interval is between start and end time, `[)` momentjs
+    // argument to include the start_time (this_time >= start_time) but not end_time (this_time < end_time)
+    return this_time.isBetween(start_time, end_time, null, '[)');
+  }
+
+  /**
+   * Display a row with the events details rendered full width.
+   * @param {Object} event - the event to render details for
+   * @param {number} i - the events index
+   * @returns {JSX} - the TR element
+   * @private
+   */
+  _eventDetailRow(event, i) {
+    return (
+      <tr key={`event.${i}.detail`} className={`event-detail-row ${event.room_shortname}`}>
+        <td colSpan={CLASSROOM_HOURS.length}>
+          <div>
+            <span className="event-title">{event.title}</span>
+            <span>{event.contact}</span>
+            <span>{event.room}</span>
+          </div>
+        </td>
+      </tr>
+    )
+  }
+
+  /**
+   * Given the events start_time and end_time, iterate through each of the configured classroom hours and
+   * render cells for each 15min increment which the event is active. The effect is to display a cell for each hour,
+   * but show it subdivided with 15min spans to give a visual representation of each interval when the event is active.
+   * @param {Moment} date - the current day which the schedule is displaying
+   * @param {Object} event - the event to render times for
+   * @param {number} i - the events index
+   * @returns {JSX} - the TR element
+   * @private
+   */
+  _eventTimeRow(date, event, i) {
+    const start_time = moment(event.start_time);
+    const end_time = moment(event.end_time);
+
+    return (
+      <tr key={`event.${i}.time`} className={`event-time-row ${event.room_shortname}`}>
+        {CLASSROOM_HOURS.map((h) => {
+          const hour = moment(date).hour(h);
+          const has_hour = this._eventIncludesTime(start_time, end_time, hour);
+          const has_15 = this._eventIncludesTime(start_time, end_time, moment(hour).add(15, 'm'));
+          const has_30 = this._eventIncludesTime(start_time, end_time, moment(hour).add(30, 'm'));
+          const has_45 = this._eventIncludesTime(start_time, end_time, moment(hour).add(45, 'm'));
+          const hour_has_event = has_hour || has_15 || has_30 || has_45;
+          return (
+            <td key={`event.${i}.${hour}`} className={hour_has_event ? "event-hour" : ""}>
+              <span key={`event.${i}.hour.header`} className="event-hour-header">
+                {hour.format('h a')}
+              </span>
+              <span key={`event.${i}.00`} className={has_hour ? "event-time" : ""}>&nbsp;</span>
+              <span key={`event.${i}.15`} className={has_15 ? "event-time" : ""}>&nbsp;</span>
+              <span key={`event.${i}.30`} className={has_30 ? "event-time" : ""}>&nbsp;</span>
+              <span key={`event.${i}.45`} className={has_45 ? "event-time" : ""}>&nbsp;</span>
+            </td>
+          )
+        })}
+      </tr>
+    )
+  }
+
+  /**
+   * An event has a detail row followed by the event time row so that the detail can have full width of the table
+   * and the time cells (15min increments) are colored and lined up properly on the x axis.
+   * @param {Object} classrooms - the classrooms from the application state
+   * @param {Object} events - the events from the application state
+   * @param {Moment} date - the day which the schedule is being rendered
+   * @returns {JSX} - rows of event details/times or indication if there are no events
+   * @private
+   */
+  _getEventRows(classrooms, events, date) {
+    if (!events || !events.length) {
+      return (<tr>
+        <td>No classrooms scheduled.</td>
+      </tr>);
+    } else {
+      const rows = [];
+      this._filteredEvents(classrooms, events).map((e, i) => {
+        rows.push(this._eventDetailRow(e, i));
+        rows.push(this._eventTimeRow(date, e, i));
+      });
+      return rows;
+    }
+  }
+
+  /**
+   * Show only events which relate to the currently selected classrooms from the filter
+   * @param {Object} classrooms - the classrooms from the application state
+   * @param {Object} events - the events from the application state
+   * @returns {*} - a filtered list of events
+   * @private
+   */
+  _filteredEvents(classrooms, events) {
+    const selected = Object.values(classrooms).filter((c) => c.selected == true);
+    if (selected.length == Object.values(classrooms).length) {
+      return events;
+    }
+    return Object.values(events).filter((e) => selected.some((s) => s.shortname == e.room_shortname));
+  }
+
+  render() {
+    const events = this.props.classroom_schedule.events;
+    const classrooms = this.props.classrooms;
+    let date = this.props.date;
+    if (date == '') {
+      return null;
+    }
+    date = moment(date);
+    return (
+      <table className="table classroom-schedule-table">
+        <thead>
+        <tr key="event.header" className="event-header-row">
+          <th colSpan={CLASSROOM_HOURS.length}>
+            <div>
+              <span>Event Title</span>
+              <span>Contact</span>
+              <span>Location</span>
+            </div>
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        {this._getEventRows(classrooms, events, date)}
+        </tbody>
+      </table>);
+  }
+}
+
+ClassroomScheduleDay.propTypes = {
+  date: PropTypes.string.isRequired,
+  classrooms: PropTypes.object.isRequired,
+  classroom_schedule: PropTypes.object.isRequired,
+  is_fetching_classroom_schedule: PropTypes.bool.isRequired,
+};
+
+export default ClassroomScheduleDay;

--- a/app/assets/javascripts/react/components/presentational/Touch/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Header.js
@@ -1,18 +1,29 @@
 import React, {Component, PropTypes} from 'react';
 import TouchHours from '../../TouchHours';
 import ConnectedTabbedPanel from '../../TabbedPanel';
+import ConnectedClassroomSchedule from '../../TouchClassroomSchedule';
 
 class Header extends Component {
+  /**
+   * Refresh button was clicked, fire off actions to fetch the latest slides and reset
+   * the gallery scroll position
+   */
   refreshClicked() {
     this.props.fetchSlides(this.props.url);
     this.props.scrollToSlide(0);
   }
 
+  /**
+   * Hours button was clicked, set the modal to display the connected Hours component
+   */
   hoursClicked() {
     this.props.setModalVisibility(true);
     this.props.setModalRootComponent(<TouchHours />);
   }
 
+  /**
+   * Maps button was clicked, set the modal to display the connected tab panel component
+   */
   mapsClicked() {
     let tabs = this.props.maps.map((m) => {
       return {
@@ -27,6 +38,19 @@ class Header extends Component {
                                                            timeout={30000}/>);
   }
 
+  /**
+   * The classroom schedule button was clicked, set the modal to display the connected classroom schedule component
+   */
+  classroomScheduleClicked() {
+    this.props.setModalVisibility(true);
+    this.props.setModalRootComponent(<ConnectedClassroomSchedule />);
+  }
+
+  /**
+   * Generate a Maps button if there are maps to display
+   * @returns {JSX} - the LI element containing the maps button
+   * @private
+   */
   _mapsButton() {
     if (this.props.maps) {
       return (
@@ -50,7 +74,7 @@ class Header extends Component {
                   <span className="icon-bar"></span>
                   <span className="icon-bar"></span>
                 </button>
-                <img className="logo" src="/assets/beaverlogo.png"/>
+                <img className="logo" src="/images/beaverlogo.png"/>
               </div>
               <div id="navbar" className="navbar-collapse collapse">
                 <ul className="nav navbar-nav">
@@ -58,6 +82,9 @@ class Header extends Component {
                     <a className="btn btn-navbar btn-default">Hours</a>
                   </li>
                   {this._mapsButton()}
+                  <li className="show-classroom-schedule" onClick={this.classroomScheduleClicked.bind(this)}>
+                    <a className="btn btn-navbar btn-default">Classrooms Schedule</a>
+                  </li>
                 </ul>
                 <ul className="nav navbar-nav navbar-right">
                   <li className="refresh-slides" onClick={this.refreshClicked.bind(this)}>

--- a/app/assets/javascripts/react/components/presentational/Touch/Hours.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Hours.js
@@ -12,11 +12,18 @@ export const getWeekArray = (date) => {
 };
 
 class Hours extends Component {
+  /**
+   * Initialize an hours UI and set the initial state to display "today"
+   * @param props - the properties passed into the component
+   */
   constructor(props) {
     super(props);
     this.state = {selected_date: now};
   }
 
+  /**
+   * Set the modal to automatically hide itself after a period of time, unless the timeout is cleared beforehand
+   */
   setHideTimeout() {
     const hide = () => {
       this.props.setModalRootComponent(undefined);
@@ -25,6 +32,10 @@ class Hours extends Component {
     this.hide_timeout = setTimeout(hide, 20000);
   }
 
+  /**
+   * Change the component to display the date that was clicked, and reset the hide timeout.
+   * @param {Moment} date - the date that was clicked
+   */
   dateClicked(date) {
     this.setState({selected_date: date});
     this.props.fetchHours(this.props.api.hours, getWeekArray(date));
@@ -32,15 +43,27 @@ class Hours extends Component {
     this.setHideTimeout();
   }
 
+  /**
+   * After the component mounts, fetch a weeks worth of hours for the date that was selected (defaulting to 'now')
+   */
   componentDidMount() {
     this.props.fetchHours(this.props.api.hours, getWeekArray(now));
     this.setHideTimeout();
   }
 
+  /**
+   * Before the component unmounts, clear the hide timeout
+   */
   componentWillUnmount() {
     clearTimeout(this.hide_timeout);
   }
 
+  /**
+   * Render the hours table or error depending on the result of fetching the hours
+   * @param {Object} hours - the hours returned from the server
+   * @returns {JSX} - the HoursTable or HoursError depending on the servers return
+   * @private
+   */
   _hoursContent(hours) {
     if (hours.error) {
       return (<HoursError error={hours.error}/>);
@@ -49,12 +72,16 @@ class Hours extends Component {
     }
   }
 
+  /**
+   * Includes Bootstrap elements for mobile and regular displays using hidden-*  and col-* semantics
+   * @returns {JSX} - the rendered UI
+   */
   render() {
     let hours = this.props.hours;
     let calendar = (<Calendar defaultValue={default_calendar_value}
                               onChange={this.dateClicked.bind(this)}
                               showDateInput={false}/>);
-    let is_fetching_class = this.props.is_fetching ? "is_fetching" : "";
+    let is_fetching_class = this.props.is_fetching_hours ? "is_fetching" : "";
     return (
       <div id="hours" className="panel panel-default">
         <div className="panel-heading">

--- a/app/assets/javascripts/react/components/presentational/shared/ModalWindow.js
+++ b/app/assets/javascripts/react/components/presentational/shared/ModalWindow.js
@@ -22,9 +22,6 @@ class ModalWindow extends Component {
         id: "modal_close"
       },
       "");
-    if (!root_component && this.props.visible) {
-      console.error(`ModalWindow called to display a null root_component, unable to render.`);
-    }
     return (
       <div id="modal" style={{display: display}} onClick={this.closeModal.bind(this)}>
         {root_component ? close_icon_component : undefined }

--- a/app/assets/javascripts/react/reducers/kioskReducer.js
+++ b/app/assets/javascripts/react/reducers/kioskReducer.js
@@ -4,7 +4,9 @@ export const initial_state = {
   type: "touch",
   url: "kiosk/touch",
   api: {
-    hours: "/api/v1/hours"
+    hours: "/api/v1/hours",
+    classroom_schedule: "/api/v1/classrooms/date/{date}",
+    classrooms: "/api/v1/classrooms/rooms"
   },
   title: "Donor Impact",
   slides: [],

--- a/app/assets/javascripts/react/reducers/touchReducer.js
+++ b/app/assets/javascripts/react/reducers/touchReducer.js
@@ -1,26 +1,50 @@
-import {FETCHED_SLIDES, FETCHING_SLIDES, FETCHED_HOURS, FETCHING_HOURS, SET_HOURS, SET_MAPS} from '../actions/touchActions';
+import {
+  FETCHED_SLIDES, FETCHING_SLIDES, FETCHED_HOURS, FETCHING_HOURS, SET_HOURS, SET_MAPS,
+  FETCHED_CLASSROOM_SCHEDULE, FETCHING_CLASSROOM_SCHEDULE, SET_CLASSROOM_SCHEDULE,
+  FETCHED_CLASSROOMS, FETCHING_CLASSROOMS, TOGGLE_CLASSROOM_SELECTED
+} from '../actions/touchActions';
 
 export const initial_state = {
   is_fetching_slides: false,
   is_fetching_hours: false,
+  is_fetching_classroom_schedule: false,
+  is_fetching_classrooms: false,
   hours: {},
+  classroom_schedule: {},
+  classrooms: {},
+  date: '',
   maps: []
 };
 
 const touchReducer = (state = initial_state, action) => {
+  let classrooms = [];
   switch (action.type) {
     case FETCHED_SLIDES:
-      return Object.assign({}, state, { is_fetching_slides: false });
+      return Object.assign({}, state, {is_fetching_slides: false});
     case FETCHING_SLIDES:
-      return Object.assign({}, state, { is_fetching_slides: true });
+      return Object.assign({}, state, {is_fetching_slides: true});
     case FETCHED_HOURS:
-      return Object.assign({}, state, { is_fetching_hours: false });
+      return Object.assign({}, state, {is_fetching_hours: false});
     case FETCHING_HOURS:
-      return Object.assign({}, state, { is_fetching_hours: true });
+      return Object.assign({}, state, {is_fetching_hours: true});
     case SET_HOURS:
-      return Object.assign({}, state, { hours: action.hours });
+      return Object.assign({}, state, {hours: action.hours});
+    case FETCHED_CLASSROOM_SCHEDULE:
+      return Object.assign({}, state, {is_fetching_classroom_schedule: false});
+    case FETCHING_CLASSROOM_SCHEDULE:
+      return Object.assign({}, state, {is_fetching_classroom_schedule: true});
+    case SET_CLASSROOM_SCHEDULE:
+      return Object.assign({}, state, {date: action.data.date, classroom_schedule: action.data.classroom_schedule});
     case SET_MAPS:
-      return Object.assign({}, state, { maps: action.maps });
+      return Object.assign({}, state, {maps: action.maps});
+    case FETCHED_CLASSROOMS:
+      return Object.assign({}, state, {is_fetching_classrooms: false, classrooms: action.classrooms});
+    case FETCHING_CLASSROOMS:
+      return Object.assign({}, state, {is_fetching_classrooms: true});
+    case TOGGLE_CLASSROOM_SELECTED:
+      let classrooms = Object.assign({}, state.classrooms);
+      classrooms[action.data.shortname].selected = !action.data.selected;
+      return Object.assign({}, state, {classrooms});
     default:
       return state;
   }

--- a/app/assets/stylesheets/layouts/_touch-kiosk.scss
+++ b/app/assets/stylesheets/layouts/_touch-kiosk.scss
@@ -1,6 +1,11 @@
 @import "../../../node_modules/react-image-gallery/styles/scss/image-gallery.scss";
 @import "../../../node_modules/rc-calendar/assets/index";
 
+$willwest: #3d5cff;
+$willeast: #ff3c5c;
+$barnard: #6eff7e;
+$autzen: #ea76ff;
+
 /* Set container elements to 100% height. */
 #touch_kiosk, #slide_gallery, .image-gallery {
   height: 100%;
@@ -186,7 +191,7 @@
       vertical-align: bottom;
     }
     .hours-table-error > .glyphicon {
-      font-size:30px;
+      font-size: 30px;
     }
   }
 
@@ -197,6 +202,149 @@
       li,
       li > div {
         height: 90%;
+      }
+    }
+  }
+
+  #classroom_schedule {
+    .panel-title {
+      font-size: 30px;
+    }
+    .panel-heading .glyphicon {
+      color: $shaded_grey;
+      width: 20px;
+      height: 20px;
+      font-size: 20px;
+      float: right;
+      display: none;
+      margin-top: 10px;
+    }
+    .glyphicon.is_fetching {
+      display: inline-block;
+    }
+    .classroom-schedule-table-container {
+
+      h2 {
+        text-align: center;
+      }
+      .classroom-filter {
+        border-bottom: solid 1px #efefef;
+        padding-bottom: 10px;
+        font-size: large;
+        ul {
+          list-style: none;
+        }
+        ul li {
+          float: left;
+          margin: 0 20px;
+        }
+        ul li:first-child {
+          text-align: right;
+          color: #cecece;
+        }
+        ul li .glyphicon {
+          margin-right: 5px;
+          width: 20px;
+          color: #adadad;
+        }
+        ul li .glyphicon.checked {
+          color: #000;
+        }
+        ul li.lib-willwest .glyphicon.checked {
+          color: $willwest;
+        }
+        ul li.lib-willeast .glyphicon.checked {
+          color: $willeast;
+        }
+        ul li.lib-barnard .glyphicon.checked {
+          color: $barnard;
+        }
+        ul li.lib-autzen .glyphicon.checked {
+          color: $autzen;
+        }
+      }
+      .classroom-schedule-table {
+        margin-top: 20px;
+        thead tr th,
+        tbody tr td {
+          border: none;
+        }
+        thead tr th,
+        tbody tr td {
+          padding: 0;
+        }
+        thead tr.event-header-row th div,
+        tbody tr.event-detail-row td div {
+          float: left;
+          width: 100%;
+        }
+        tbody tr.event-detail-row td div {
+          padding-top: 15px;
+        }
+        thead tr.event-header-row th div span {
+          font-weight: normal;
+          color: #cecece;
+          font-size: large;
+        }
+        thead tr.event-header-row th div span,
+        tbody tr.event-detail-row td div span {
+          display: inline-block;
+          width: 30%;
+          vertical-align: bottom;
+          text-align: center;
+        }
+        tbody tr.event-detail-row td div span.event-title {
+          font-size: large;
+          text-align: left;
+        }
+
+        tbody tr.event-time-row td {
+          border-top: solid 1px #ececec;
+        }
+        tbody tr.event-time-row td span {
+          width: 25%;
+          float: left;
+        }
+        tbody tr.event-time-row td span.event-hour-header {
+          width: 100%;
+          float: left;
+          font-size: 10px;
+          display: none;
+          background-color: transparent;
+        }
+        tbody tr.event-time-row td.event-hour span {
+          border-left: solid 1px #adadad;
+          background-color: #ececec;
+          line-height: 15px;
+        }
+        tbody tr.event-time-row td.event-hour span.event-hour-header {
+          display: inline-block;
+          border-left: solid 1px #adadad;
+          padding-left: 3px;
+        }
+        tbody tr.event-time-row td.event-hour span.event-time {
+          background-color: #000;
+          margin-bottom: 5px;
+          border: none;
+        }
+
+        tbody tr.lib-willwest td.event-hour span.event-time {
+          background-color: $willwest;
+          border-left: solid 1px darken($willwest, 25%);
+        }
+        tbody tr.lib-willeast td.event-hour span.event-time {
+          background-color: $willeast;
+          border-left: solid 1px darken($willeast, 25%);
+        }
+        tbody tr.lib-barnard td.event-hour span.event-time {
+          background-color: $barnard;
+          border-left: solid 1px darken($barnard, 25%);
+        }
+        tbody tr.lib-autzen td.event-hour span.event-time {
+          background-color: $autzen;
+          border-left: solid 1px darken($autzen, 25%);
+        }
+
       }
     }
   }
@@ -223,4 +371,5 @@
     }
   }
 }
+
 

--- a/app/models/api/v1/classroom_event.rb
+++ b/app/models/api/v1/classroom_event.rb
@@ -1,18 +1,23 @@
 module Api
   module V1
     class ClassroomEvent
-      attr_reader :title, :link, :start_time, :end_time, :subtitle, :room, :contact, :contact_phone, :contact_email
+      attr_reader :title, :link, :start_time, :end_time, :subtitle, :room, :contact, :contact_phone, :contact_email, :room_shortname
 
-      def initialize(hash)
-        @title = hash['title']
-        @link = hash['link']
-        @start_time = hash['dtstart']
-        @end_time = hash['dtend']
-        @subtitle = hash['subtitle']
-        @room = hash['room']
-        @contact = hash['contact']
-        @contact_email = hash['contact_email']
-        @contact_phone = hash['contact_phone']
+      ##
+      # Initialize a classroom event
+      # @param [Nokogiri::XML::Node] node - the xml node with this events markup
+      def initialize(node)
+        #TODO : Extract the mapping of attribute name to xpath
+        @title = node.at('title').text
+        @link = node.at('link').text
+        @start_time = Time.zone.parse(node.at_xpath('edu.oregonstate.calendar:dtstart').text).strftime("%Y%m%dT%H%M")
+        @end_time = Time.zone.parse(node.at_xpath('edu.oregonstate.calendar:dtend').text).strftime("%Y%m%dT%H%M")
+        @subtitle = node.at_xpath('edu.oregonstate.calendar:subtitle').text
+        @room = node.at_xpath('edu.oregonstate.calendar:room').text
+        @room_shortname = node.at_xpath('edu.oregonstate.calendar:calendar').attr('shortname')
+        @contact = node.at_xpath('edu.oregonstate.calendar:contact').text
+        @contact_email = node.at_xpath('edu.oregonstate.calendar:contact_email').text
+        @contact_phone = node.at_xpath('edu.oregonstate.calendar:contact_phone').text
       end
     end
   end

--- a/config/application_config.example.yml.erb
+++ b/config/application_config.example.yml.erb
@@ -33,17 +33,20 @@ api:
       cached_minutes: 30
     rooms:
       -
+        shortname: "library"
+        title: "The Valley Library"
+      -
+        shortname: "lib-autzen"
+        title: "Autzen"
+      -
+        shortname: "lib-barnard"
+        title: "Barnard"
+      -
         shortname: "lib-willeast"
         title: "Willamette East"
       -
         shortname: "lib-willwest"
         title: "Willamette West"
-      -
-        shortname: "lib-barnard"
-        title: "Barnard"
-      -
-        shortname: "lib-autzen"
-        title: "Autzen"
   database:
     roomres:
       reservations:

--- a/spec/javascripts/react/.factories.js
+++ b/spec/javascripts/react/.factories.js
@@ -38,7 +38,16 @@ export const error = {
 
 export const kiosk = {
   type: "touch",
-  url: "/url/to/action"
+  url: "/url/to/action",
+  api: {
+    hours: "/api/v1/hours",
+    classroom_schedule: "/api/v1/classrooms/date/{date}",
+    classrooms: "/api/v1/classrooms/rooms"
+  },
+  title: "",
+  slides: [],
+  starting_slide_index: 0,
+  errors: []
 };
 
 export const hours = {
@@ -53,4 +62,30 @@ export const hours = {
 export const map = {
   title: "Floor 1",
   image_url: "/assets/images/FloorMaps/floor_0.png"
+};
+
+export const classroom_schedule =
+{
+  title: "OSU Libraries",
+  link: "http://calendar.oregonstate.edu/20170110/day/library/",
+  description: "",
+  published_at: "Tue, 10 Jan 2017 11:09:56 PST",
+  events: [{
+    "title": "Data Analytics - Jaspersoft",
+    "link": "http://calendar.oregonstate.edu/event/120763/",
+    "start_time": "20170110T1000",
+    "end_time": "20170110T1130",
+    "subtitle": "Person",
+    "room": "Barnard Classroom",
+    "room_shortname": "lib-barnard",
+    "contact": "Person",
+    "contact_email": "noreply@oregonstate.edu",
+    "contact_phone": "1 541 555 1212"
+  }]
+};
+
+export const classroom = {
+  shortname: "test_shortname",
+  title: "Title",
+  selected: true
 };

--- a/spec/javascripts/react/components/__snapshots__/DonorKiosk.test.js.snap
+++ b/spec/javascripts/react/components/__snapshots__/DonorKiosk.test.js.snap
@@ -1,13 +1,20 @@
 exports[`Donor Kiosk maps dispatch to props 1`] = `
 Object {
   "addError": [Function],
+  "fetchClassroomSchedule": [Function],
+  "fetchClassrooms": [Function],
   "fetchHours": [Function],
   "fetchSlides": [Function],
+  "fetchedClassroomSchedule": [Function],
+  "fetchedClassrooms": [Function],
   "fetchedHours": [Function],
   "fetchedSlides": [Function],
+  "fetchingClassroomSchedule": [Function],
+  "fetchingClassrooms": [Function],
   "fetchingHours": [Function],
   "fetchingSlides": [Function],
   "scrollToSlide": [Function],
+  "setClassroomSchedule": [Function],
   "setHours": [Function],
   "setKiosk": [Function],
   "setMaps": [Function],
@@ -15,6 +22,7 @@ Object {
   "setModalVisibility": [Function],
   "setSlides": [Function],
   "setTitle": [Function],
+  "toggleClassroomSelected": [Function],
 }
 `;
 

--- a/spec/javascripts/react/components/__snapshots__/DonorSlideGrid.test.js.snap
+++ b/spec/javascripts/react/components/__snapshots__/DonorSlideGrid.test.js.snap
@@ -1,19 +1,28 @@
 exports[`Donor SlideGrid maps dispatch to props 1`] = `
 Object {
   "addError": [Function],
+  "fetchClassroomSchedule": [Function],
+  "fetchClassrooms": [Function],
   "fetchHours": [Function],
   "fetchSlides": [Function],
+  "fetchedClassroomSchedule": [Function],
+  "fetchedClassrooms": [Function],
   "fetchedHours": [Function],
   "fetchedSlides": [Function],
+  "fetchingClassroomSchedule": [Function],
+  "fetchingClassrooms": [Function],
   "fetchingHours": [Function],
   "fetchingSlides": [Function],
   "scrollToSlide": [Function],
+  "setClassroomSchedule": [Function],
   "setHours": [Function],
   "setKiosk": [Function],
+  "setMaps": [Function],
   "setModalRootComponent": [Function],
   "setModalVisibility": [Function],
   "setSlides": [Function],
   "setTitle": [Function],
+  "toggleClassroomSelected": [Function],
 }
 `;
 

--- a/spec/javascripts/react/components/__snapshots__/Error.test.js.snap
+++ b/spec/javascripts/react/components/__snapshots__/Error.test.js.snap
@@ -1,13 +1,20 @@
 exports[`Error maps dispatch to props 1`] = `
 Object {
   "addError": [Function],
+  "fetchClassroomSchedule": [Function],
+  "fetchClassrooms": [Function],
   "fetchHours": [Function],
   "fetchSlides": [Function],
+  "fetchedClassroomSchedule": [Function],
+  "fetchedClassrooms": [Function],
   "fetchedHours": [Function],
   "fetchedSlides": [Function],
+  "fetchingClassroomSchedule": [Function],
+  "fetchingClassrooms": [Function],
   "fetchingHours": [Function],
   "fetchingSlides": [Function],
   "scrollToSlide": [Function],
+  "setClassroomSchedule": [Function],
   "setHours": [Function],
   "setKiosk": [Function],
   "setMaps": [Function],
@@ -15,6 +22,7 @@ Object {
   "setModalVisibility": [Function],
   "setSlides": [Function],
   "setTitle": [Function],
+  "toggleClassroomSelected": [Function],
 }
 `;
 

--- a/spec/javascripts/react/components/__snapshots__/SlideGallery.test.js.snap
+++ b/spec/javascripts/react/components/__snapshots__/SlideGallery.test.js.snap
@@ -1,13 +1,20 @@
 exports[`SlideGallery maps dispatch to props 1`] = `
 Object {
   "addError": [Function],
+  "fetchClassroomSchedule": [Function],
+  "fetchClassrooms": [Function],
   "fetchHours": [Function],
   "fetchSlides": [Function],
+  "fetchedClassroomSchedule": [Function],
+  "fetchedClassrooms": [Function],
   "fetchedHours": [Function],
   "fetchedSlides": [Function],
+  "fetchingClassroomSchedule": [Function],
+  "fetchingClassrooms": [Function],
   "fetchingHours": [Function],
   "fetchingSlides": [Function],
   "scrollToSlide": [Function],
+  "setClassroomSchedule": [Function],
   "setHours": [Function],
   "setKiosk": [Function],
   "setMaps": [Function],
@@ -15,6 +22,7 @@ Object {
   "setModalVisibility": [Function],
   "setSlides": [Function],
   "setTitle": [Function],
+  "toggleClassroomSelected": [Function],
 }
 `;
 

--- a/spec/javascripts/react/components/presentational/shared/ModalWindow.test.js
+++ b/spec/javascripts/react/components/presentational/shared/ModalWindow.test.js
@@ -27,14 +27,6 @@ describe('Snapshot', () => {
   });
 });
 describe('Shared::ModalWindow', () => {
-  it('logs a console.error when visible with no root_component', () => {
-    global.console = jest.fn();
-    global.console.error = jest.fn();
-    let { component } = setup({visible: true, element: undefined });
-    let tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
-    expect(global.console.error.mock.calls.length).toEqual(1);
-  });
   it('can be closed', () => {
     let {component, props} = setup({visible: true, element: React.createElement("H1", {}, "test")});
     let tree = component.toJSON();

--- a/spec/javascripts/react/components/presentational/shared/__snapshots__/modalWindow.test.js.snap
+++ b/spec/javascripts/react/components/presentational/shared/__snapshots__/modalWindow.test.js.snap
@@ -40,17 +40,6 @@ exports[`Shared::ModalWindow can be closed 2`] = `
 </div>
 `;
 
-exports[`Shared::ModalWindow logs a console.error when visible with no root_component 1`] = `
-<div
-  id="modal"
-  onClick={[Function]}
-  style={
-    Object {
-      "display": "block",
-    }
-  } />
-`;
-
 exports[`Snapshot matches the cached snapshot 1`] = `
 <div
   id="modal"

--- a/spec/javascripts/react/reducers/__snapshots__/kioskReducer.test.js.snap
+++ b/spec/javascripts/react/reducers/__snapshots__/kioskReducer.test.js.snap
@@ -1,6 +1,8 @@
 exports[`Reducers::Kiosk addError action matches the snapshot 1`] = `
 Object {
   "api": Object {
+    "classroom_schedule": "/api/v1/classrooms/date/{date}",
+    "classrooms": "/api/v1/classrooms/rooms",
     "hours": "/api/v1/hours",
   },
   "errors": Array [
@@ -22,6 +24,8 @@ exports[`Reducers::Kiosk matches the snapshot 1`] = `[Function]`;
 exports[`Reducers::Kiosk scrollToSlide action matches the snapshot 1`] = `
 Object {
   "api": Object {
+    "classroom_schedule": "/api/v1/classrooms/date/{date}",
+    "classrooms": "/api/v1/classrooms/rooms",
     "hours": "/api/v1/hours",
   },
   "errors": Array [],
@@ -36,6 +40,8 @@ Object {
 exports[`Reducers::Kiosk setKiosk action matches the snapshot 1`] = `
 Object {
   "api": Object {
+    "classroom_schedule": "/api/v1/classrooms/date/{date}",
+    "classrooms": "/api/v1/classrooms/rooms",
     "hours": "/api/v1/hours",
   },
   "errors": Array [],
@@ -43,6 +49,15 @@ Object {
   "starting_slide_index": 0,
   "title": "Donor Impact",
   "type": Object {
+    "api": Object {
+      "classroom_schedule": "/api/v1/classrooms/date/{date}",
+      "classrooms": "/api/v1/classrooms/rooms",
+      "hours": "/api/v1/hours",
+    },
+    "errors": Array [],
+    "slides": Array [],
+    "starting_slide_index": 0,
+    "title": "",
     "type": "touch",
     "url": "/url/to/action",
   },
@@ -53,6 +68,8 @@ Object {
 exports[`Reducers::Kiosk setSlides action matches the snapshot 1`] = `
 Object {
   "api": Object {
+    "classroom_schedule": "/api/v1/classrooms/date/{date}",
+    "classrooms": "/api/v1/classrooms/rooms",
     "hours": "/api/v1/hours",
   },
   "errors": Array [],
@@ -94,6 +111,8 @@ Object {
 exports[`Reducers::Kiosk setTitle action matches the snapshot 1`] = `
 Object {
   "api": Object {
+    "classroom_schedule": "/api/v1/classrooms/date/{date}",
+    "classrooms": "/api/v1/classrooms/rooms",
     "hours": "/api/v1/hours",
   },
   "errors": Array [],

--- a/spec/javascripts/react/reducers/__snapshots__/touchReducer.test.js.snap
+++ b/spec/javascripts/react/reducers/__snapshots__/touchReducer.test.js.snap
@@ -1,6 +1,39 @@
+exports[`Reducers::Touch fetchedClassroomSchedule action matches the snapshot 1`] = `
+Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
+  "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
+  "is_fetching_hours": false,
+  "is_fetching_slides": false,
+  "maps": Array [],
+}
+`;
+
+exports[`Reducers::Touch fetchedClassrooms action matches the snapshot 1`] = `
+Object {
+  "classroom_schedule": Object {},
+  "classrooms": undefined,
+  "date": "",
+  "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
+  "is_fetching_hours": false,
+  "is_fetching_slides": false,
+  "maps": Array [],
+}
+`;
+
 exports[`Reducers::Touch fetchedHours action matches the snapshot 1`] = `
 Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
   "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
   "is_fetching_hours": false,
   "is_fetching_slides": false,
   "maps": Array [],
@@ -9,7 +42,40 @@ Object {
 
 exports[`Reducers::Touch fetchedSlides action matches the snapshot 1`] = `
 Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
   "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
+  "is_fetching_hours": false,
+  "is_fetching_slides": false,
+  "maps": Array [],
+}
+`;
+
+exports[`Reducers::Touch fetchingClassroomSchedule action matches the snapshot 1`] = `
+Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
+  "hours": Object {},
+  "is_fetching_classroom_schedule": true,
+  "is_fetching_classrooms": false,
+  "is_fetching_hours": false,
+  "is_fetching_slides": false,
+  "maps": Array [],
+}
+`;
+
+exports[`Reducers::Touch fetchingClassrooms action matches the snapshot 1`] = `
+Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
+  "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": true,
   "is_fetching_hours": false,
   "is_fetching_slides": false,
   "maps": Array [],
@@ -18,7 +84,12 @@ Object {
 
 exports[`Reducers::Touch fetchingHours action matches the snapshot 1`] = `
 Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
   "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
   "is_fetching_hours": true,
   "is_fetching_slides": false,
   "maps": Array [],
@@ -27,7 +98,12 @@ Object {
 
 exports[`Reducers::Touch fetchingSlides action matches the snapshot 1`] = `
 Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
   "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
   "is_fetching_hours": false,
   "is_fetching_slides": true,
   "maps": Array [],
@@ -36,8 +112,44 @@ Object {
 
 exports[`Reducers::Touch matches the snapshot 1`] = `[Function]`;
 
+exports[`Reducers::Touch setClassroomSchedule action matches the snapshot 1`] = `
+Object {
+  "classroom_schedule": Object {
+    "description": "",
+    "events": Array [
+      Object {
+        "contact": "Person",
+        "contact_email": "noreply@oregonstate.edu",
+        "contact_phone": "1 541 555 1212",
+        "end_time": "20170110T1130",
+        "link": "http://calendar.oregonstate.edu/event/120763/",
+        "room": "Barnard Classroom",
+        "room_shortname": "lib-barnard",
+        "start_time": "20170110T1000",
+        "subtitle": "Person",
+        "title": "Data Analytics - Jaspersoft",
+      },
+    ],
+    "link": "http://calendar.oregonstate.edu/20170110/day/library/",
+    "published_at": "Tue, 10 Jan 2017 11:09:56 PST",
+    "title": "OSU Libraries",
+  },
+  "classrooms": Object {},
+  "date": "20170110",
+  "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
+  "is_fetching_hours": false,
+  "is_fetching_slides": false,
+  "maps": Array [],
+}
+`;
+
 exports[`Reducers::Touch setHours action matches the snapshot 1`] = `
 Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
   "hours": Object {
     "2000-01-01": Object {
       "close": "2am",
@@ -46,8 +158,39 @@ Object {
       "string_date": "Jan 01, 2000",
     },
   },
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
   "is_fetching_hours": false,
   "is_fetching_slides": false,
   "maps": Array [],
+}
+`;
+
+exports[`Reducers::Touch setMaps action matches the snapshot 1`] = `
+Object {
+  "classroom_schedule": Object {},
+  "classrooms": Object {},
+  "date": "",
+  "hours": Object {},
+  "is_fetching_classroom_schedule": false,
+  "is_fetching_classrooms": false,
+  "is_fetching_hours": false,
+  "is_fetching_slides": false,
+  "maps": Object {
+    "image_url": "/assets/images/FloorMaps/floor_0.png",
+    "title": "Floor 1",
+  },
+}
+`;
+
+exports[`Reducers::Touch toggleClassroomSelected action matches the snapshot 1`] = `
+Object {
+  "classrooms": Object {
+    "test_shortname": Object {
+      "selected": true,
+      "shortname": "test_shortname",
+      "title": "Title",
+    },
+  },
 }
 `;

--- a/spec/javascripts/react/reducers/touchReducer.test.js
+++ b/spec/javascripts/react/reducers/touchReducer.test.js
@@ -33,4 +33,40 @@ describe('Reducers::Touch', () => {
       expect(reducerCreator(empty_state, actionCreator.setHours(factories.hours))).toMatchSnapshot();
     })
   });
+  describe('fetchedClassroomSchedule action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.fetchedClassroomSchedule())).toMatchSnapshot();
+    })
+  });
+  describe('fetchingClassroomSchedule action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.fetchingClassroomSchedule())).toMatchSnapshot();
+    })
+  });
+  describe('fetchedClassrooms action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.fetchedClassrooms())).toMatchSnapshot();
+    })
+  });
+  describe('fetchingClassrooms action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.fetchingClassrooms())).toMatchSnapshot();
+    })
+  });
+  describe('setClassroomSchedule action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.setClassroomSchedule(factories.classroom_schedule, '20170110'))).toMatchSnapshot();
+    })
+  });
+  describe('setMaps action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.setMaps(factories.map))).toMatchSnapshot();
+    })
+  });
+  describe('toggleClassroomSelected action', () => {
+    it('matches the snapshot', () => {
+      let the_state = { classrooms: { test_shortname: factories.classroom } };
+      expect(reducerCreator(the_state, actionCreator.toggleClassroomSelected(factories.classroom.shortname, false))).toMatchSnapshot();
+    })
+  });
 });

--- a/spec/models/api/v1/classroom_calendar_spec.rb
+++ b/spec/models/api/v1/classroom_calendar_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Api::V1::ClassroomCalendar do
     event = calendar.detail[:events].first
     expect(event.title).to eq('Jaspersoft Training')
     expect(event.link).to eq('http://calendar.oregonstate.edu/event/122043/')
-    expect(event.start_time).to eq('Wed, 04 Jan 2017 08:30:00 PST')
-    expect(event.end_time).to eq('Wed, 04 Jan 2017 12:00:00 PST')
+    expect(event.start_time).to eq('20170104T0830')
+    expect(event.end_time).to eq('20170104T1200')
     expect(event.room).to eq('Barnard Classroom')
   end
 end

--- a/spec/models/api/v1/classroom_event_spec.rb
+++ b/spec/models/api/v1/classroom_event_spec.rb
@@ -1,28 +1,21 @@
 require 'rails_helper'
+require 'nokogiri'
 
 RSpec.describe Api::V1::ClassroomEvent do
   subject { Api::V1::ClassroomEvent }
-  let(:hash) { {
-    "title" => "title",
-    "link" => "http://blah.blah.blah",
-    "dtstart" => "Sun, 08 Jan 2017 18:00:00 PST",
-    "dtend" => "Sun, 08 Jan 2017 20:00:00 PST",
-    "subtitle" => "subtitle",
-    "room" => "some room",
-    "contact" => "person",
-    "contact_email" => "email",
-    "contact_phone" => "phone"
-  } }
-  let(:event) { subject.new hash }
+  let(:xml_doc) { Nokogiri::XML(File.open("spec/fixtures/api/v1/classroom_schedule.xml"))}
+  let(:xml_statement) { xml_doc.xpath("rss/channel/item").first }
+  let(:event) { subject.new xml_statement }
 
   it 'has details' do
-    expect(event.title).to eq(hash['title'])
-    expect(event.link).to eq(hash['link'])
-    expect(event.start_time).to eq(hash['dtstart'])
-    expect(event.end_time).to eq(hash['dtend'])
-    expect(event.room).to eq(hash['room'])
-    expect(event.contact).to eq(hash['contact'])
-    expect(event.contact_phone).to eq(hash['contact_phone'])
-    expect(event.contact_email).to eq(hash['contact_email'])
+    expect(event.title).to eq("Jaspersoft Training")
+    expect(event.link).to eq("http://calendar.oregonstate.edu/event/122043/")
+    expect(event.start_time).to eq("20170104T0830")
+    expect(event.end_time).to eq("20170104T1200")
+    expect(event.room).to eq("Barnard Classroom")
+    expect(event.room_shortname).to eq("lib-barnard")
+    expect(event.contact).to eq("Person Name")
+    expect(event.contact_phone).to eq("541-555-1212")
+    expect(event.contact_email).to eq("noreply@oregonstate.edu")
   end
 end


### PR DESCRIPTION
Touch kiosk UI for interacting with classroom schedule api backend.. 

TODO: 
- Translate each event row into a horizontally aligned bar with color coding per room to indicate what time segments are reserved for that event.
- Organize the UI so that the day events calendar is at the top of the view, and the bottom of the view is split into a filter grid and calendar side-by-side 

```
|--------------------------------------------------|
                Full Day Event Calendar                           
|--------------------------------------------------|
     Room Filter Grid        |     Calendar Picker   
|--------------------------------------------------|
```

