### PR TITLE
classroom schedule production bugfix

### DIFF
--- a/app/assets/javascripts/react/components/TouchClassroomSchedule.js
+++ b/app/assets/javascripts/react/components/TouchClassroomSchedule.js
@@ -10,7 +10,7 @@ const mapStateToProps = (state) => {
   return {
     classrooms: state.touch.classrooms,
     is_fetching_classrooms: state.touch.is_fetching_classrooms,
-    is_fetching_classroom_schedule: state.touch.is_fetching_classroom_schedule
+    api: state.kiosk.api
   }
 };
 

--- a/app/assets/javascripts/react/components/presentational/Touch/ClassroomSchedule.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/ClassroomSchedule.js
@@ -147,11 +147,9 @@ class ClassroomSchedule extends Component {
 }
 
 ClassroomSchedule.propTypes = {
-  classroom_schedule: PropTypes.object.isRequired,
   classrooms: PropTypes.object.isRequired,
   api: PropTypes.object.isRequired,
   is_fetching_classroom_schedule: PropTypes.bool.isRequired,
-  is_fetching_classrooms: PropTypes.bool.isRequired,
   fetchClassroomSchedule: PropTypes.func.isRequired,
   fetchClassrooms: PropTypes.func.isRequired,
   toggleClassroomSelected: PropTypes.func.isRequired,


### PR DESCRIPTION
fixes classroom schedule in production, which has JS aggressively pruned by webpack causing the property to be missing in this circumstance