### PR TITLE
updated kiosk to use formatted hours instead of open/close values

### DIFF
--- a/app/assets/javascripts/react/components/presentational/Circulation/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Circulation/Header.js
@@ -17,10 +17,7 @@ class Header extends Component {
       return "";
     } else {
       let today = Object.values(this.props.hours)[0];
-      if(today.open.trim() == '12:00am' && today.close.trim() == '12:00am') {
-        return `Open 24 hours on ${today.string_date}`;
-      }
-      return `Open from ${today.open.trim()} to ${today.close.trim()} on ${today.string_date}`;
+      return `${today.formatted_hours.trim()} on ${today.string_date}`;
     }
   }
 

--- a/app/assets/javascripts/react/components/presentational/Touch/ClassroomScheduleDay.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/ClassroomScheduleDay.js
@@ -35,7 +35,7 @@ class ClassroomScheduleDay extends Component {
         <td colSpan={CLASSROOM_HOURS.length}>
           <div>
             <span className="event-title">{event.title}</span>
-            <span>{event.contact}</span>
+            <span></span>
             <span>{event.room}</span>
           </div>
         </td>
@@ -177,7 +177,7 @@ class ClassroomScheduleDay extends Component {
           <th colSpan={CLASSROOM_HOURS.length}>
             <div>
               <span>Event Title</span>
-              <span>Contact</span>
+              <span></span>
               <span>Location</span>
             </div>
           </th>

--- a/app/assets/javascripts/react/components/presentational/Touch/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Header.js
@@ -97,10 +97,7 @@ class Header extends Component {
       return "";
     } else {
       let today = Object.values(this.props.hours)[0];
-      if(today.open.trim() == '12:00am' && today.close.trim() == '12:00am') {
-        return `Open 24 hours on ${today.string_date}`;
-      }
-      return `Open from ${today.open.trim()} to ${today.close.trim()} on ${today.string_date}`;
+      return `${today.formatted_hours.trim()} on ${today.string_date}`;
     }
   }
 

--- a/app/assets/javascripts/react/components/presentational/Touch/Hours.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Hours.js
@@ -57,6 +57,7 @@ class Hours extends Component {
    * Before the component unmounts, clear the hide timeout
    */
   componentWillUnmount() {
+    this.props.fetchHours(this.props.api.hours, [now]);
     clearTimeout(this.hide_timeout);
   }
 

--- a/app/assets/javascripts/react/components/presentational/Touch/HoursTable.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/HoursTable.js
@@ -9,8 +9,7 @@ class HoursTable extends Component {
         <thead>
         <tr>
           <th></th>
-          <th>Open</th>
-          <th>Close</th>
+          <th>Hours</th>
         </tr>
         </thead>
         <tbody>
@@ -18,8 +17,7 @@ class HoursTable extends Component {
           return (
             <tr key={`hours.${i}`} className={moment(h.sortable_date).isSame(this.props.selected_date, "day") ? "alert alert-info" : ""}>
               <td>{h.string_date}</td>
-              <td>{h.open}</td>
-              <td>{h.close}</td>
+              <td>{h.formatted_hours}</td>
             </tr>
           )
         })}

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe CollectionsController, type: :controller do
     { name: "" }
   }
 
-  let(:uploaded_files_attributes) {
-    { name: "my collection"}
-  }
-
   let(:user) do
     User.create(
       :email => 'user@example.com',

--- a/spec/views/date_ranges/index.html.erb_spec.rb
+++ b/spec/views/date_ranges/index.html.erb_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "date_ranges/index", type: :view do
 
   before(:each) do
     assign(:date_ranges, [
-      DateRange.create!(valid_attributes_2),
+      DateRange.create!(valid_attributes_1),
       DateRange.create!(valid_attributes_2)
     ])
   end


### PR DESCRIPTION
fixes #114 

- Updated the hours table and the kiosk headers (touch, and circulation) so that they display the formatted hours instead of the raw open/close values, see screenshot bellow

Touch kiosk header
![image](https://cloud.githubusercontent.com/assets/3486120/24674546/aa6087ae-1930-11e7-8df6-3c8e40f4736f.png)

Circulation header
![image](https://cloud.githubusercontent.com/assets/3486120/24674491/7802e5c2-1930-11e7-8f8e-d889dbba0524.png)

- Updated Hours.js so that when the hours popup is closed, the headers will show today's hours instead of the previously selected hours in the calendar

- Screenshot for new hours popup

![image](https://cloud.githubusercontent.com/assets/3486120/24670896/ac1dd422-1924-11e7-97fa-664699032c3b.png)

- Removed the contact column from the classroom schedule windows as requested by Circulation

![image](https://cloud.githubusercontent.com/assets/3486120/24674233/9dab9e82-192f-11e7-97b8-c11de39e1131.png)
