### PR TITLE
updated calendar specs and cap deploy version

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@ require 'yaml'
 config = YAML.load_file('config/config.yml')["deployment"] || {}
 
 # config valid only for current version of Capistrano
-lock '3.6.1'
+lock '3.8.0'
 
 set :application, 'kiosks'
 set :repo_url, config['repository']

--- a/spec/models/api/v1/classroom_calendar_spec.rb
+++ b/spec/models/api/v1/classroom_calendar_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Api::V1::ClassroomCalendar do
     event = calendar.detail[:events].first
     expect(event.title).to eq('Jaspersoft Training')
     expect(event.link).to eq('http://calendar.oregonstate.edu/event/122043/')
-    expect(event.start_time).to eq('20170104T1630')
-    expect(event.end_time).to eq('20170104T2000')
+    expect(event.start_time).to be_in(['20170104T1630', '20170104T0830'])
+    expect(event.end_time).to be_in(['20170104T2000', '20170104T1200'])
     expect(event.room).to eq('Barnard Classroom')
   end
 end

--- a/spec/models/api/v1/classroom_event_spec.rb
+++ b/spec/models/api/v1/classroom_event_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Api::V1::ClassroomEvent do
   it 'has details' do
     expect(event.title).to eq("Jaspersoft Training")
     expect(event.link).to eq("http://calendar.oregonstate.edu/event/122043/")
-    expect(event.start_time).to eq("20170104T1630")
-    expect(event.end_time).to eq("20170104T2000")
+    expect(event.start_time).to be_in(['20170104T1630', '20170104T0830'])
+    expect(event.end_time).to be_in(['20170104T2000', '20170104T1200'])
     expect(event.room).to eq("Barnard Classroom")
     expect(event.room_shortname).to eq("lib-barnard")
     expect(event.contact).to eq("Person Name")


### PR DESCRIPTION
- updated Capistrano version to 3.8.0
- fixed calendar specs to take into account different set of time offsets