### PR TITLE
updated hours window and bullet slide css

### DIFF
--- a/app/assets/javascripts/react/components/presentational/Touch/Hours.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Hours.js
@@ -26,11 +26,10 @@ class Hours extends Component {
    * Set the modal to automatically hide itself after a period of time, unless the timeout is cleared beforehand
    */
   setHideTimeout() {
-    const hide = () => {
+    this.hide_timeout = setInterval(() => {
       this.props.setModalRootComponent(undefined);
       this.props.setModalVisibility(false);
-    };
-    this.hide_timeout = setTimeout(hide, 20000);
+    }, 2*10*1000);
   }
 
   /**
@@ -41,7 +40,7 @@ class Hours extends Component {
     trackClicked(this.props.google_analytics, 'TouchKiosk:Hours:Date');
     this.setState({selected_date: date});
     this.props.fetchHours(this.props.api.hours, getWeekArray(date));
-    clearTimeout(this.hide_timeout);
+    clearInterval(this.hide_timeout);
     this.setHideTimeout();
   }
 
@@ -49,8 +48,8 @@ class Hours extends Component {
    * After the component mounts, fetch a weeks worth of hours for the date that was selected (defaulting to 'now')
    */
   componentDidMount() {
-    this.props.fetchHours(this.props.api.hours, getWeekArray(now));
     this.setHideTimeout();
+    this.props.fetchHours(this.props.api.hours, getWeekArray(now));
   }
 
   /**
@@ -58,7 +57,7 @@ class Hours extends Component {
    */
   componentWillUnmount() {
     this.props.fetchHours(this.props.api.hours, [now]);
-    clearTimeout(this.hide_timeout);
+    clearInterval(this.hide_timeout);
   }
 
   /**

--- a/app/assets/stylesheets/layouts/_touch-kiosk.scss
+++ b/app/assets/stylesheets/layouts/_touch-kiosk.scss
@@ -21,18 +21,20 @@ $autzen: #ea76ff;
     bottom: 0;
     width: 100%;
   }
+
   .image-gallery-bullet {
-    background-color: rgba(255, 255, 255, 0.54) !important;
+    background-color: rgba(200, 54, 54, 0.5) !important;
     border-color: rgba(255, 255, 255, 0.90) !important;
-    -webkit-box-shadow: none !important;
-    -moz-box-shadow: none !important;
-    box-shadow: none !important;
+    -webkit-box-shadow: 2px 1px 0 #1a1a1a !important;
+    -moz-box-shadow: 2px 1px 0 #1a1a1a !important;
     padding: 15px;
   }
 
   .image-gallery-bullet.active {
     background-color: $osu_orange !important;
     border-color: $not_quite_black !important;
+    -webkit-box-shadow: 1px 1px 0 #1a1a1a !important;
+    -moz-box-shadow: 1px 1px 0 #1a1a1a !important;
     border-width: 2px;
     padding: 18px;
   }


### PR DESCRIPTION
- used intervals instead of timeouts in the hours component in the hours window
- updated the css so that the bullets used to switch slides would show the proper contrast depending on the background:

![image](https://cloud.githubusercontent.com/assets/3486120/25760402/768404f6-318b-11e7-86ab-5de2dbf1a8ac.png)

![image](https://cloud.githubusercontent.com/assets/3486120/25760418/87b84674-318b-11e7-800c-7e76b0e663e6.png)
