### PR TITLE
fixes a bug dealing with time zone parsing and translating

### DIFF
--- a/app/controllers/api/v1/rooms_controller.rb
+++ b/app/controllers/api/v1/rooms_controller.rb
@@ -11,7 +11,7 @@ module Api
       def set_params
         # expecting a start date like "20160101120000"
         # the format should be YYYYMMDDHHmmss if it's set with moment.js
-        @start_time = Time.zone.parse(params[:start_time]).in_time_zone('UTC')
+        @start_time = Time.parse(params[:start_time]).in_time_zone('UTC')
         raise StandardError.new("Invalid start_time.") if @start_time.nil?
       end
     end


### PR DESCRIPTION
fixes #143 

Somehow using Rails time zone parsing and translating on the same line of code causes an intermittent bug to make an invalid SQL query using PST times.