### PR TITLE
integrate primo search in touch kiosk

### DIFF
--- a/app/assets/javascripts/react/components/TouchSearchPrimo.js
+++ b/app/assets/javascripts/react/components/TouchSearchPrimo.js
@@ -1,0 +1,22 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import SearchPrimo from './presentational/Touch/SearchPrimo';
+import * as actions from '../actions';
+
+// Top level mapping of the application state to properties of component that is being
+// connected.
+const mapStateToProps = (state) => {
+  return {
+    api: state.kiosk.api,
+    google_analytics: state.kiosk.google_analytics,
+  }
+};
+
+// Map the actions to the dispatcher
+const mapDispatchToProps = (dispatch) => {
+  return bindActionCreators(actions, dispatch);
+};
+
+// Connect the mappings (state -> properties, and actions -> dispatch) to the application component
+export default connect(mapStateToProps, mapDispatchToProps)(SearchPrimo);

--- a/app/assets/javascripts/react/components/presentational/Touch/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Header.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import TouchHours from '../../TouchHours';
 import ConnectedTabbedPanel from '../../TabbedPanel';
 import ConnectedClassroomSchedule from '../../TouchClassroomSchedule';
+import ConnectedSearchPrimo from '../../TouchSearchPrimo';
 import {trackClicked} from '../shared/GoogleAnalytics';
 
 class Header extends Component {
@@ -71,6 +72,15 @@ class Header extends Component {
     this.props.setModalVisibility(true);
     this.props.setModalRootComponent(<ConnectedClassroomSchedule />);
   }
+  
+  /**
+   * The 1search button was clicked, set the modal to display the connected search primo component
+   */
+  searchPrimoClicked() {
+    trackClicked(this.props.google_analytics, 'TouchKiosk:Header:SearchPrimo');
+    this.props.setModalVisibility(true);
+    this.props.setModalRootComponent(<ConnectedSearchPrimo />);
+  }
 
   /**
    * Generate a Maps button if there are maps to display
@@ -127,6 +137,9 @@ class Header extends Component {
                   {this._mapsButton()}
                   <li className="show-classroom-schedule" onClick={this.classroomScheduleClicked.bind(this)}>
                     <a className="btn btn-navbar btn-default">Classrooms Schedule</a>
+                  </li>
+                  <li className="show-search-primo" onClick={this.searchPrimoClicked.bind(this)}>
+                    <a className="btn btn-navbar btn-default">1Search</a>
                   </li>
                 </ul>
                 <ul className="nav navbar-nav navbar-right">

--- a/app/assets/javascripts/react/components/presentational/Touch/SearchPrimo.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/SearchPrimo.js
@@ -1,0 +1,50 @@
+import React, {Component, PropTypes} from 'react';
+import {trackClicked} from '../shared/GoogleAnalytics';
+
+var Iframe = React.createClass({
+    render: function() {
+        return(
+            <div>
+                <iframe src={this.props.src} height={this.props.height} width={this.props.width} frameBorder={0} />
+            </div>
+        )
+    }
+});
+
+class SearchPrimo extends Component {
+  /**
+   * Initialize an Search Primo UI 
+   * @param props - the properties passed into the component
+   */
+  constructor(props) {
+    super(props);
+  }
+
+  /**
+   * Includes Bootstrap elements for mobile and regular displays using hidden-*  and col-* semantics
+   * @returns {JSX} - the rendered UI
+   */
+  render() {
+    return (
+      <div id="search-primo" className="panel panel-default">
+        <div className="panel-heading">
+          <span className="panel-title">1Search</span>
+        </div>
+        <div className="container-fluid search-primo-table-container">
+          <div className="row">
+            <div className="col-sm-12">
+                <Iframe src="https://search.library.oregonstate.edu/primo-explore/search?vid=OSU&sortby=rank" height={(window.innerHeight-200).toString() + 'px'} width="100%"/>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+SearchPrimo.propTypes = {
+  api: PropTypes.object.isRequired,
+  google_analytics: PropTypes.object,
+};
+
+export default SearchPrimo;


### PR DESCRIPTION
fixes #136 

added `1Search` button and an iframe component to render primo search UI in a touch kiosk component

![image](https://user-images.githubusercontent.com/3486120/34267940-b87f106e-e633-11e7-853e-954b6e13cba3.png)

![image](https://user-images.githubusercontent.com/3486120/34267919-a70dd2f2-e633-11e7-8256-8665b2e39257.png)
