### PR TITLE
added restart_at field to kiosk model

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,6 @@
 //= require dragscroll
 //= require date_range_actions
 //= require kiosk_restart_actions
-//= require kiosks
 //= require react
 //= require react_ujs
 //= require cable

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,8 @@
 //= require fileupload
 //= require dragscroll
 //= require date_range_actions
+//= require kiosk_restart_actions
+//= require kiosks
 //= require react
 //= require react_ujs
 //= require cable

--- a/app/assets/javascripts/kiosk_restart_actions.js.coffee
+++ b/app/assets/javascripts/kiosk_restart_actions.js.coffee
@@ -1,0 +1,44 @@
+jQuery ->
+  $(document).on("change", 'input.enable_restart_at', (event) ->
+    if this.checked == true
+
+      $(".field.restart_at").removeClass('hidden')
+    else
+      $(".field.restart_at").addClass('hidden')
+
+
+#    $(target).find('input.timepicker_start').datetimepicker('show')
+  )
+  $('#set_today_btn').on 'click', ->
+    field = 'kiosk_restart_at'
+    dt = new Date()
+
+    t1 = $('#' + field + '_1i')
+    t1.val(dt.getFullYear())
+
+    t2 = $('#' + field + '_2i')
+    t2.val(dt.getMonth() + 1)
+
+    t3 = $('#' + field + '_3i')
+    t3.val(dt.getDate())
+
+    t4 = $('#' + field + '_4i')
+    if dt.getHours() < 10
+      hours = "0" + dt.getHours()
+    else
+      hours = dt.getHours()
+
+    t4.val(hours)
+
+    t5 = $('#' + field + '_5i')
+    if dt.getMinutes() < 10
+      min = "0" + dt.getMinutes()
+    else
+      min = dt.getMinutes()
+
+    t5.val(min)
+
+#  $('#collapseKioskRestart').on 'hide.bs.collapse', ->
+#    $('#add_restart').text('+ Add one-time restart date/time')
+#    $("#collapseKioskRestart select option[value='']").attr('selected', true)
+

--- a/app/assets/javascripts/kiosk_restart_actions.js.coffee
+++ b/app/assets/javascripts/kiosk_restart_actions.js.coffee
@@ -1,14 +1,7 @@
 jQuery ->
-  $(document).on("change", 'input.enable_restart_at', (event) ->
-    if this.checked == true
+  $('#clear_restart_at_btn').on 'click', ->
+    $(".field.restart_at select option[value='']").attr('selected', true)
 
-      $(".field.restart_at").removeClass('hidden')
-    else
-      $(".field.restart_at").addClass('hidden')
-
-
-#    $(target).find('input.timepicker_start').datetimepicker('show')
-  )
   $('#set_today_btn').on 'click', ->
     field = 'kiosk_restart_at'
     dt = new Date()
@@ -37,8 +30,3 @@ jQuery ->
       min = dt.getMinutes()
 
     t5.val(min)
-
-#  $('#collapseKioskRestart').on 'hide.bs.collapse', ->
-#    $('#add_restart').text('+ Add one-time restart date/time')
-#    $("#collapseKioskRestart select option[value='']").attr('selected', true)
-

--- a/app/assets/javascripts/kiosks.js
+++ b/app/assets/javascripts/kiosks.js
@@ -1,6 +1,0 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.
-
-//slides = [];
-$(document).ready(function(){
-});

--- a/app/assets/javascripts/kiosks.js
+++ b/app/assets/javascripts/kiosks.js
@@ -1,0 +1,6 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.
+
+//slides = [];
+$(document).ready(function(){
+});

--- a/app/assets/javascripts/react/actions/kioskActions.js
+++ b/app/assets/javascripts/react/actions/kioskActions.js
@@ -16,6 +16,17 @@ export const setSlides = (slides) => {
   };
 };
 
+export const SET_RESTART_KIOSK = 'SET_RESTART_KIOSK';
+export const setRestartKiosk = (restart_kiosk) => {
+  return {
+    type: SET_RESTART_KIOSK,
+    kiosk: {
+      restart_kiosk
+    }
+  };
+};
+
+
 export const SCROLL_TO_SLIDE = "SCROLL_TO_SLIDE";
 export const scrollToSlide = (index) => {
   return {

--- a/app/assets/javascripts/react/actions/touchActions.js
+++ b/app/assets/javascripts/react/actions/touchActions.js
@@ -49,6 +49,47 @@ export const fetchSlides = (url) => {
   };
 };
 
+export const FETCHING_RESTART_KIOSK = 'FETCHING_RESTART_KIOSK';
+export const fetchingRestartKiosk = () => {
+  return {
+    type: FETCHING_RESTART_KIOSK
+  };
+};
+
+export const FETCHED_RESTART_KIOSK = 'FETCHED_RESTART_KIOSK';
+export const fetchedRestartKiosk = () => {
+  return {
+    type: FETCHED_RESTART_KIOSK
+  };
+};
+
+/**
+ * A redux-thunk async action that fetches from the server and handles the return by dispatching a regular
+ * action depending on success or error.
+ * @param url - the url to the server for fetching restart_kiosk
+ * @returns {Redux Async Action} - see http://redux.js.org/docs/advanced/AsyncActions.html
+ */
+export const fetchRestartKiosk = (url) => {
+  return (dispatch) => {
+    dispatch(fetchingRestartKiosk());
+    return fetch(`${url}.json`)
+      .then(response => response.json())
+      .then(json => {
+        if (json.restart_kiosk == 'true'){
+          window.location.reload(true);
+        }
+        dispatch(setRestartKiosk(json.restart_kiosk));
+        setTimeout(() => {
+          dispatch(fetchedRestartKiosk());
+        }, 800);
+      })
+      .catch(err => {
+        dispatch(addError({message: err.message, code: err.code}));
+        dispatch(fetchedRestartKiosk());
+      });
+  };
+};
+
 export const SET_HOURS = 'SET_HOURS';
 export const setHours = (hours) => {
   return {

--- a/app/assets/javascripts/react/components/App.js
+++ b/app/assets/javascripts/react/components/App.js
@@ -8,7 +8,8 @@ import * as actions from '../actions';
 // connected.
 const mapStateToProps = (state) => {
   return {
-    slides: state.slides
+    slides: state.slides,
+    restart_kiosk: state.restart_kiosk
   }
 };
 

--- a/app/assets/javascripts/react/components/CirculationKiosk.js
+++ b/app/assets/javascripts/react/components/CirculationKiosk.js
@@ -9,8 +9,10 @@ import * as actions from '../actions';
 export const mapStateToProps = (state) => {
   return {
     slides: state.kiosk.slides,
+    restart_kiosk: state.kiosk.restart_kiosk,
     url: state.kiosk.url,
     is_fetching_slides: state.touch.is_fetching_slides,
+    is_fetching_restart_kiosk: state.touch.is_fetching_restart_kiosk,
     show_nav: state.circ.show_nav,
     rooms_available_count: state.circ.rooms_available_count,
     api: state.kiosk.api,

--- a/app/assets/javascripts/react/components/CirculationKiosk.js
+++ b/app/assets/javascripts/react/components/CirculationKiosk.js
@@ -12,7 +12,6 @@ export const mapStateToProps = (state) => {
     restart_kiosk: state.kiosk.restart_kiosk,
     url: state.kiosk.url,
     is_fetching_slides: state.touch.is_fetching_slides,
-    is_fetching_restart_kiosk: state.touch.is_fetching_restart_kiosk,
     show_nav: state.circ.show_nav,
     rooms_available_count: state.circ.rooms_available_count,
     api: state.kiosk.api,

--- a/app/assets/javascripts/react/components/DonorKiosk.js
+++ b/app/assets/javascripts/react/components/DonorKiosk.js
@@ -9,6 +9,8 @@ import * as actions from '../actions';
 export const mapStateToProps = (state) => {
   return {
     slides: state.kiosk.slides,
+    restart_kiosk: state.kiosk.restart_kiosk,
+    url: state.kiosk.url,
     title: state.kiosk.title,
     google_analytics: state.kiosk.google_analytics
   }

--- a/app/assets/javascripts/react/components/Root.js
+++ b/app/assets/javascripts/react/components/Root.js
@@ -22,9 +22,9 @@ export default class Root extends Component {
     store.dispatch(setSlides(this.props.slides));
     store.dispatch(setRestartKiosk(this.props.restart_kiosk));
     store.dispatch(setMaps(this.props.maps));
-    // if(typeof this.props.google_analytics != 'undefined') {
-    //   store.dispatch(setGoogleAnalytics(this.props.google_analytics));
-    // }
+    if(typeof this.props.google_analytics != 'undefined') {
+      store.dispatch(setGoogleAnalytics(this.props.google_analytics));
+    }
   }
 
   /**

--- a/app/assets/javascripts/react/components/Root.js
+++ b/app/assets/javascripts/react/components/Root.js
@@ -7,7 +7,7 @@ import App from './App';
 import TouchKiosk from './TouchKiosk';
 import DonorKiosk from './DonorKiosk';
 import CirculationKiosk from './CirculationKiosk';
-import {setKiosk, setSlides, setGoogleAnalytics} from '../actions/kioskActions';
+import {setKiosk, setSlides, setRestartKiosk, setGoogleAnalytics} from '../actions/kioskActions';
 import {setMaps} from '../actions/touchActions';
 
 const store = configureStore();
@@ -20,10 +20,11 @@ export default class Root extends Component {
   componentWillMount() {
     store.dispatch(setKiosk(this.props.kiosk_type, this.props.kiosk_url));
     store.dispatch(setSlides(this.props.slides));
+    store.dispatch(setRestartKiosk(this.props.restart_kiosk));
     store.dispatch(setMaps(this.props.maps));
-    if(typeof this.props.google_analytics != 'undefined') {
-      store.dispatch(setGoogleAnalytics(this.props.google_analytics));
-    }
+    // if(typeof this.props.google_analytics != 'undefined') {
+    //   store.dispatch(setGoogleAnalytics(this.props.google_analytics));
+    // }
   }
 
   /**

--- a/app/assets/javascripts/react/components/TouchKiosk.js
+++ b/app/assets/javascripts/react/components/TouchKiosk.js
@@ -17,7 +17,6 @@ const mapStateToProps = (state) => {
     api: state.kiosk.api,
     classroom_schedule: state.touch.classroom_schedule,
     is_fetching_slides: state.touch.is_fetching_slides,
-    is_fetching_restart_kiosk: state.touch.is_fetching_restart_kiosk,
     is_fetching_hours: state.touch.is_fetching_hours,
     show_nav: state.touch.show_nav
   }

--- a/app/assets/javascripts/react/components/TouchKiosk.js
+++ b/app/assets/javascripts/react/components/TouchKiosk.js
@@ -9,6 +9,7 @@ import * as actions from '../actions';
 const mapStateToProps = (state) => {
   return {
     slides: state.kiosk.slides,
+    restart_kiosk: state.kiosk.restart_kiosk,
     maps: state.touch.maps,
     hours: state.touch.hours,
     url: state.kiosk.url,
@@ -16,6 +17,7 @@ const mapStateToProps = (state) => {
     api: state.kiosk.api,
     classroom_schedule: state.touch.classroom_schedule,
     is_fetching_slides: state.touch.is_fetching_slides,
+    is_fetching_restart_kiosk: state.touch.is_fetching_restart_kiosk,
     is_fetching_hours: state.touch.is_fetching_hours,
     show_nav: state.touch.show_nav
   }

--- a/app/assets/javascripts/react/components/presentational/Circulation/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Circulation/Header.js
@@ -37,7 +37,7 @@ class Header extends Component {
           </div>
           <div id="navbar" className="navbar-collapse collapse">
             <div className="circ-title">Announcements</div>
-            <div className="circ-hours navbar-text">{this._hoursToday()}hola mundo</div>
+            <div className="circ-hours navbar-text">{this._hoursToday()}</div>
           </div>
         </nav>
       </div>

--- a/app/assets/javascripts/react/components/presentational/Circulation/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Circulation/Header.js
@@ -37,7 +37,7 @@ class Header extends Component {
           </div>
           <div id="navbar" className="navbar-collapse collapse">
             <div className="circ-title">Announcements</div>
-            <div className="circ-hours navbar-text">{this._hoursToday()}</div>
+            <div className="circ-hours navbar-text">{this._hoursToday()}hola mundo</div>
           </div>
         </nav>
       </div>

--- a/app/assets/javascripts/react/components/presentational/Circulation/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Circulation/Kiosk.js
@@ -13,8 +13,10 @@ class Kiosk extends Component {
     let now = moment().format('YYYY-MM-DD');
     this._fetchHoursTimeout();
     this._fetchSlidesTimeout();
+    this._fetchRestartKioskTimeout();
     this.props.fetchHours(this.props.api.hours, [now]);
     this.props.fetchSlides(this.props.url);
+    this.props.fetchRestartKiosk(this.props.url);
   }
 
   /**
@@ -23,6 +25,7 @@ class Kiosk extends Component {
   componentWillUnmount() {
     clearInterval(this.hours_timeout);
     clearInterval(this.slides_timeout);
+    clearInterval(this.restart_kiosk_timeout);
   }
 
   /**
@@ -34,6 +37,16 @@ class Kiosk extends Component {
       let now = moment().format('YYYY-MM-DD');
       this.props.fetchHours(this.props.api.hours, [now]);
     }, 10 * 60 * 1000);
+  }
+
+  /**
+   * Fetch the restart_kiosk value for "now" every 1 minute, to restart the kiosk when needed
+   * @private
+   */
+  _fetchRestartKioskTimeout() {
+    this.restart_kiosk_timeout = setInterval(() => {
+      this.props.fetchRestartKiosk(this.props.url);
+    }, 1 * 60 * 1000);
   }
 
   /**
@@ -69,10 +82,13 @@ class Kiosk extends Component {
 
 Kiosk.propTypes = {
   slides: PropTypes.array.isRequired,
+  restart_kiosk: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   is_fetching_slides: PropTypes.bool.isRequired,
+  is_fetching_restart_kiosk: PropTypes.bool.isRequired,
   show_nav: PropTypes.bool.isRequired,
   fetchSlides: PropTypes.func.isRequired,
+  fetchRestartKiosk: PropTypes.func.isRequired,
   scrollToSlide: PropTypes.func.isRequired,
   api: PropTypes.object.isRequired,
   hours: PropTypes.object.isRequired,

--- a/app/assets/javascripts/react/components/presentational/Circulation/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Circulation/Kiosk.js
@@ -40,7 +40,7 @@ class Kiosk extends Component {
   }
 
   /**
-   * Fetch the restart_kiosk value for "now" every 1 minute, to restart the kiosk when needed
+   * Fetch the restart_kiosk value for circulation kiosk every 1 minute in order to restart the kiosk as scheduled
    * @private
    */
   _fetchRestartKioskTimeout() {
@@ -85,7 +85,6 @@ Kiosk.propTypes = {
   restart_kiosk: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   is_fetching_slides: PropTypes.bool.isRequired,
-  is_fetching_restart_kiosk: PropTypes.bool.isRequired,
   show_nav: PropTypes.bool.isRequired,
   fetchSlides: PropTypes.func.isRequired,
   fetchRestartKiosk: PropTypes.func.isRequired,

--- a/app/assets/javascripts/react/components/presentational/Donor/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Donor/Kiosk.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 
 class Kiosk extends Component {
   /**
-   * After the component mounts, fetch the
+   * After the component mounts, fetch the restart_kiosk value
    */
   componentDidMount() {
     this._fetchRestartKioskTimeout();
@@ -21,7 +21,7 @@ class Kiosk extends Component {
   }
 
   /**
-   * Fetch the restart_kiosk value for "now" every 1 minute, to restart the kiosk when needed
+   * Fetch the restart_kiosk value for donor kiosk every 1 minute in order to restart the kiosk as scheduled
    * @private
    */
   _fetchRestartKioskTimeout() {

--- a/app/assets/javascripts/react/components/presentational/Donor/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Donor/Kiosk.js
@@ -2,8 +2,34 @@ import {connect} from 'react-redux';
 import React, {Component, PropTypes} from 'react';
 import ConnectedModalWindow from '../../ModalWindow';
 import ConnectedSlideGrid from '../../DonorSlideGrid';
+import moment from 'moment';
 
 class Kiosk extends Component {
+  /**
+   * After the component mounts, fetch the
+   */
+  componentDidMount() {
+    this._fetchRestartKioskTimeout();
+    this.props.fetchRestartKiosk(this.props.url);
+  }
+
+  /**
+   * Before the component unmounts, clear the timeouts.
+   */
+  componentWillUnmount() {
+    clearInterval(this.restart_kiosk_timeout);
+  }
+
+  /**
+   * Fetch the restart_kiosk value for "now" every 1 minute, to restart the kiosk when needed
+   * @private
+   */
+  _fetchRestartKioskTimeout() {
+    this.restart_kiosk_timeout = setInterval(() => {
+      this.props.fetchRestartKiosk(this.props.url);
+    }, 1 * 60 * 1000);
+  }
+
   render() {
     return (
       <div id="donor_kiosk">
@@ -16,9 +42,12 @@ class Kiosk extends Component {
 
 Kiosk.propTypes = {
   slides: PropTypes.array.isRequired,
+  restart_kiosk: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
   google_analytics: PropTypes.object.isRequired,
   setModalVisibility: PropTypes.func.isRequired,
+  fetchRestartKiosk: PropTypes.func.isRequired,
   setModalRootComponent: PropTypes.func.isRequired,
   setTitle: PropTypes.func.isRequired,
 };

--- a/app/assets/javascripts/react/components/presentational/Touch/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Header.js
@@ -82,6 +82,10 @@ class Header extends Component {
     this.props.setModalRootComponent(<ConnectedSearchPrimo />);
   }
 
+  refreshNow() {
+      window.location.reload();
+  }
+
   /**
    * Generate a Maps button if there are maps to display
    * @returns {JSX} - the LI element containing the maps button
@@ -141,6 +145,9 @@ class Header extends Component {
                   <li className="show-search-primo hidden" onClick={this.searchPrimoClicked.bind(this)}>
                     <a className="btn btn-navbar btn-default">1Search</a>
                   </li>
+                  <li className="show-refresh" onClick={this.refreshNow.bind(this)}>
+                    <a className="btn btn-navbar btn-default">Refresh</a>
+                  </li>
                 </ul>
                 <ul className="nav navbar-nav navbar-right">
                   <li className="refresh-slides" onClick={this.refreshClicked.bind(this)}>
@@ -151,7 +158,7 @@ class Header extends Component {
                     </a>
                   </li>
                 </ul>
-                <p className="hours navbar-text">{this._hoursToday()}</p>
+                <p className="hours navbar-text">{this._hoursToday()} hola mundo</p>
               </div>
             </div>
           </nav>

--- a/app/assets/javascripts/react/components/presentational/Touch/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Header.js
@@ -82,10 +82,6 @@ class Header extends Component {
     this.props.setModalRootComponent(<ConnectedSearchPrimo />);
   }
 
-  refreshNow() {
-      window.location.reload();
-  }
-
   /**
    * Generate a Maps button if there are maps to display
    * @returns {JSX} - the LI element containing the maps button
@@ -145,9 +141,6 @@ class Header extends Component {
                   <li className="show-search-primo hidden" onClick={this.searchPrimoClicked.bind(this)}>
                     <a className="btn btn-navbar btn-default">1Search</a>
                   </li>
-                  <li className="show-refresh" onClick={this.refreshNow.bind(this)}>
-                    <a className="btn btn-navbar btn-default">Refresh</a>
-                  </li>
                 </ul>
                 <ul className="nav navbar-nav navbar-right">
                   <li className="refresh-slides" onClick={this.refreshClicked.bind(this)}>
@@ -158,7 +151,7 @@ class Header extends Component {
                     </a>
                   </li>
                 </ul>
-                <p className="hours navbar-text">{this._hoursToday()} hola mundo</p>
+                <p className="hours navbar-text">{this._hoursToday()}</p>
               </div>
             </div>
           </nav>

--- a/app/assets/javascripts/react/components/presentational/Touch/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Kiosk.js
@@ -13,8 +13,10 @@ class Kiosk extends Component {
     let now = moment().format('YYYY-MM-DD');
     this._fetchHoursTimeout();
     this._fetchSlidesTimeout();
+    this._fetchRestartKioskTimeout();
     this.props.fetchHours(this.props.api.hours, [now]);
     this.props.fetchSlides(this.props.url);
+    this.props.fetchRestartKiosk(this.props.url);
   }
 
   /**
@@ -23,6 +25,7 @@ class Kiosk extends Component {
   componentWillUnmount() {
     clearInterval(this.hours_timeout);
     clearInterval(this.slides_timeout);
+    clearInterval(this.restart_kiosk_timeout);
   }
 
   /**
@@ -47,6 +50,16 @@ class Kiosk extends Component {
   }
 
   /**
+   * Fetch the most recent slides every 10 minutes to keep the kiosk with updated slides as they are changed on the server.
+   * @private
+   */
+  _fetchRestartKioskTimeout() {
+    this.restart_kiosk_timeout = setInterval(() => {
+      this.props.fetchRestartKiosk(this.props.url);
+    }, 1 * 60 * 1000);
+  }
+
+  /**
    * Render the kiosk with a hidden modal window for popup UIs driven by buttons in the header, with a rotating
    * slide gallery at the bottom of the view.
    * @returns {JSX}
@@ -64,14 +77,17 @@ class Kiosk extends Component {
 
 Kiosk.propTypes = {
   slides: PropTypes.array.isRequired,
+  restart_kiosk: PropTypes.string.isRequired,
   maps: PropTypes.array,
   hours: PropTypes.object.isRequired,
   url: PropTypes.string.isRequired,
   google_analytics: PropTypes.object,
   api: PropTypes.object.isRequired,
   is_fetching_slides: PropTypes.bool.isRequired,
+  is_fetching_restart_kiosk: PropTypes.bool.isRequired,
   show_nav: PropTypes.bool.isRequired,
   fetchSlides: PropTypes.func.isRequired,
+  fetchRestartKiosk: PropTypes.func.isRequired,
   setModalVisibility: PropTypes.func.isRequired,
   setModalRootComponent: PropTypes.func.isRequired,
   scrollToSlide: PropTypes.func.isRequired,

--- a/app/assets/javascripts/react/components/presentational/Touch/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Kiosk.js
@@ -50,7 +50,7 @@ class Kiosk extends Component {
   }
 
   /**
-   * Fetch the most recent slides every 10 minutes to keep the kiosk with updated slides as they are changed on the server.
+   * Fetch the restart_kiosk value for touch kiosk every 1 minute in order to restart the kiosk as scheduled
    * @private
    */
   _fetchRestartKioskTimeout() {
@@ -84,7 +84,6 @@ Kiosk.propTypes = {
   google_analytics: PropTypes.object,
   api: PropTypes.object.isRequired,
   is_fetching_slides: PropTypes.bool.isRequired,
-  is_fetching_restart_kiosk: PropTypes.bool.isRequired,
   show_nav: PropTypes.bool.isRequired,
   fetchSlides: PropTypes.func.isRequired,
   fetchRestartKiosk: PropTypes.func.isRequired,

--- a/app/assets/javascripts/react/main.js
+++ b/app/assets/javascripts/react/main.js
@@ -13,6 +13,15 @@ const setSlides = (slides) => {
   return json.slides ? json.slides : json;
 };
 
+const setRestartKiosk = (restart_kiosk) => {
+  if(!restart_kiosk) {
+    return [];
+  }
+  let json = JSON.parse(restart_kiosk);
+  return json.restart_kiosk ? json.restart_kiosk : json;
+};
+
+
 const setMaps = (maps) => {
   if(!maps) {
     return [];
@@ -23,6 +32,7 @@ const setMaps = (maps) => {
 
 if (root_dom_element) {
   let slides = setSlides(root_dom_element.getAttribute('data-slides'));
+  let restart_kiosk = setRestartKiosk(root_dom_element.getAttribute('data-restart-kiosk'));
   let maps = setMaps(root_dom_element.getAttribute('data-maps'));
   let kiosk_type = root_dom_element.getAttribute('data-kiosk-type');
   let kiosk_url = root_dom_element.getAttribute('data-kiosk-url');
@@ -31,6 +41,7 @@ if (root_dom_element) {
   // render the root container with properties
   ReactDOM.render(
     <Root slides={slides}
+          restart_kiosk={restart_kiosk}
           maps={maps}
           kiosk_type={kiosk_type}
           kiosk_url={kiosk_url}

--- a/app/assets/javascripts/react/reducers/kioskReducer.js
+++ b/app/assets/javascripts/react/reducers/kioskReducer.js
@@ -1,4 +1,4 @@
-import {SCROLL_TO_SLIDE, SET_SLIDES, SET_KIOSK, ADD_ERROR, SET_TITLE, SET_GOOGLE_ANALYTICS} from '../actions/kioskActions';
+import {SCROLL_TO_SLIDE, SET_SLIDES, SET_RESTART_KIOSK, SET_KIOSK, ADD_ERROR, SET_TITLE, SET_GOOGLE_ANALYTICS} from '../actions/kioskActions';
 
 export const initial_state = {
   type: "touch",
@@ -11,6 +11,7 @@ export const initial_state = {
   },
   title: "",
   slides: [],
+  restart_kiosk: "",
   starting_slide_index: 0,
   errors: [],
   google_analytics: undefined
@@ -22,6 +23,8 @@ const kioskReducer = (state = initial_state, action) => {
       return Object.assign({}, state, { errors: [...state.errors, action.error] });
     case SET_KIOSK:
       return Object.assign({}, state, { type: action.kiosk.type, url: action.kiosk.url });
+    case SET_RESTART_KIOSK:
+      return Object.assign({}, state, { restart_kiosk: action.kiosk.restart_kiosk });
     case SET_SLIDES:
       return Object.assign({}, state, { slides: action.kiosk.slides });
     case SCROLL_TO_SLIDE:

--- a/app/assets/javascripts/react/reducers/touchReducer.js
+++ b/app/assets/javascripts/react/reducers/touchReducer.js
@@ -1,11 +1,12 @@
 import {
-  FETCHED_SLIDES, FETCHING_SLIDES, FETCHED_HOURS, FETCHING_HOURS, SET_HOURS, SET_MAPS,
+  FETCHED_SLIDES, FETCHING_SLIDES, FETCHED_RESTART_KIOSK, FETCHING_RESTART_KIOSK, FETCHED_HOURS, FETCHING_HOURS, SET_HOURS, SET_MAPS,
   FETCHED_CLASSROOM_SCHEDULE, FETCHING_CLASSROOM_SCHEDULE, SET_CLASSROOM_SCHEDULE,
   FETCHED_CLASSROOMS, FETCHING_CLASSROOMS, TOGGLE_CLASSROOM_SELECTED
 } from '../actions/touchActions';
 
 export const initial_state = {
   is_fetching_slides: false,
+  is_fetching_restart_kiosk: false,
   is_fetching_hours: false,
   is_fetching_classroom_schedule: false,
   is_fetching_classrooms: false,
@@ -20,6 +21,10 @@ export const initial_state = {
 const touchReducer = (state = initial_state, action) => {
   let classrooms = [];
   switch (action.type) {
+    case FETCHED_RESTART_KIOSK:
+      return Object.assign({}, state, {is_fetching_restart_kiosk: false});
+    case FETCHING_RESTART_KIOSK:
+      return Object.assign({}, state, {is_fetching_restart_kiosk: true});
     case FETCHED_SLIDES:
       return Object.assign({}, state, {is_fetching_slides: false});
     case FETCHING_SLIDES:

--- a/app/controllers/kiosk_controller.rb
+++ b/app/controllers/kiosk_controller.rb
@@ -12,7 +12,7 @@ class KioskController < ApplicationController
     if reload_kiosk?(@kiosk)
       if @kiosk.update_attribute(:restart_at_active, false)
         @restart_kiosk = true.to_s
-        puts "restarting kiosk #{@restart_kiosk}"
+        puts "restarting #{@kiosk.name} kiosk"
       end
     end
 

--- a/app/controllers/kiosk_controller.rb
+++ b/app/controllers/kiosk_controller.rb
@@ -23,18 +23,8 @@ class KioskController < ApplicationController
   private
 
   def reload_kiosk?(kiosk)
-    if kiosk.respond_to? :restart_at
-      kiosk_restart_at = kiosk.restart_at
-      if kiosk_restart_at.present? && kiosk.restart_at_active.present?
-        if kiosk.restart_at_active == true
-          restart_at = DateTime.parse(kiosk_restart_at.to_s)
-          if restart_at < DateTime.now
-            return true
-          end
-        end
-      end
-    end
-    return false
+    return false if kiosk.restart_at.nil? || kiosk.restart_at_active.nil?
+    kiosk.restart_at_active && kiosk.restart_at < DateTime.now
   end
 
   def set_kiosk_params

--- a/app/controllers/kiosks_controller.rb
+++ b/app/controllers/kiosks_controller.rb
@@ -79,14 +79,6 @@ class KiosksController < ApplicationController
 
     def set_options
       @kiosk_layouts = KioskLayout.all
-      @is_collapsed = (restart_kiosk?) ? '' : 'collapsed'
-      @is_expanded = (restart_kiosk?) ? 'true' : 'false'
-      @restart_button_text = (restart_kiosk?) ? '- Remove one-time restart date/time' : '+ Add one-time restart date/time'
-      @collapse_in = (restart_kiosk?) ? 'collapse in' : 'collapse'
-    end
-
-    def restart_kiosk?
-      @kiosk.present? ? @kiosk.restart_at.present? : false
     end
 
     def set_params

--- a/app/controllers/kiosks_controller.rb
+++ b/app/controllers/kiosks_controller.rb
@@ -5,7 +5,6 @@ class KiosksController < ApplicationController
   before_action :authorize
   before_action :set_params
 
-
   # GET /kiosks
   # GET /kiosks.json
   def index
@@ -67,6 +66,7 @@ class KiosksController < ApplicationController
   end
 
   private
+
     # Use callbacks to share common setup or constraints between actions.
     def set_kiosk
       @kiosk = Kiosk.find(params[:id])
@@ -74,11 +74,19 @@ class KiosksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def kiosk_params
-      params.require(:kiosk).permit(:name, :kiosk_layout_id)
+      params.require(:kiosk).permit(:name, :kiosk_layout_id, :restart_at, :restart_at_active)
     end
 
     def set_options
       @kiosk_layouts = KioskLayout.all
+      @is_collapsed = (restart_kiosk?) ? '' : 'collapsed'
+      @is_expanded = (restart_kiosk?) ? 'true' : 'false'
+      @restart_button_text = (restart_kiosk?) ? '- Remove one-time restart date/time' : '+ Add one-time restart date/time'
+      @collapse_in = (restart_kiosk?) ? 'collapse in' : 'collapse'
+    end
+
+    def restart_kiosk?
+      @kiosk.present? ? @kiosk.restart_at.present? : false
     end
 
     def set_params

--- a/app/models/kiosk.rb
+++ b/app/models/kiosk.rb
@@ -3,4 +3,11 @@ class Kiosk < ApplicationRecord
   has_many :kiosk_slides, :dependent => :destroy
   has_many :slides, through: :kiosk_slides
   validates :name, :presence => true
+  validate :restart_at_cannot_be_in_the_past
+
+  def restart_at_cannot_be_in_the_past
+    if restart_at.present? && restart_at < DateTime.now
+      errors.add(:restart_at, "(#{restart_at}) can't be in the past, please select a date in the future")
+    end
+  end
 end

--- a/app/models/kiosk.rb
+++ b/app/models/kiosk.rb
@@ -7,7 +7,7 @@ class Kiosk < ApplicationRecord
 
   def restart_at_cannot_be_in_the_past
     if restart_at.present? && restart_at < DateTime.now
-      errors.add(:restart_at, "(#{restart_at}) can't be in the past, please select a date in the future")
+      errors.add(:restart_at, "(#{restart_at}) can't be in the past, please select a date in the future, or click 'Clear' to remove the date.")
     end
   end
 end

--- a/app/views/kiosk/show.html.erb
+++ b/app/views/kiosk/show.html.erb
@@ -1,6 +1,7 @@
 <div id="application_root"
      data-kiosk-type="<%= @kiosk.kiosk_layout.name %>"
      data-slides='<%= raw(render(template: "kiosk/show.json", locals: { slides: @slides })) %>'
+     data-restart-kiosk='<%= raw(render(template: "kiosk/show.json", locals: { restart_kiosk: @restart_kiosk })) %>'
      data-maps='<%= raw(render(template: "kiosk/maps.json", locals: { maps: @maps })) %>'
      data-kiosk-url="<%= kiosk_show_url id: @kiosk.name %>"
      ></div>

--- a/app/views/kiosk/show.json.jbuilder
+++ b/app/views/kiosk/show.json.jbuilder
@@ -19,3 +19,4 @@ json.slides @slides do |slide|
     end
   end
 end
+json.restart_kiosk @restart_kiosk

--- a/app/views/kiosks/_form.html.erb
+++ b/app/views/kiosks/_form.html.erb
@@ -22,15 +22,18 @@
       </div>
 
       <div class="field">
-        <%= f.label :restart_at_active %>
+        <%= f.label :restart_at_active, "Enable restarting kiosk" %>
         <%= f.check_box :restart_at_active, {:class => "enable_restart_at"} %>
       </div>
 
       <div class="field restart_at">
-        <%= f.label :restart_at, "Restart at" %><br>
+        <%= f.label :restart_at, "Restart kiosk at" %><br>
         <%= f.datetime_select :restart_at, {:include_blank => true, :select => DateTime.now}, {class: 'datetime-form-control form-inline'} %>
         <button type="button" id="set_today_btn" class="btn btn-default" autocomplete="off">
           Set to Today
+        </button>
+        <button type="button" id="clear_restart_at_btn" class="btn btn-default" autocomplete="off">
+          Clear
         </button>
       </div>
 

--- a/app/views/kiosks/_form.html.erb
+++ b/app/views/kiosks/_form.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
   <div class="row">
-    <div class="col-xs-6 col-md-3">
+    <div class="col-xs-12 col-md-6">
       <div class="field">
         <%= f.label :name %>
         <%= f.text_field :name, class: "form-control" %>
@@ -20,6 +20,20 @@
         <%= f.label :kiosk_layout_id %>
         <%= f.select('kiosk_layout_id', options_from_collection_for_select(@kiosk_layouts, :id, :name, kiosk.kiosk_layout_id), { :include_blank => '-- Select One --' }, :required => true, class: "form-control") %>
       </div>
+
+      <div class="field">
+        <%= f.label :restart_at_active %>
+        <%= f.check_box :restart_at_active, {:class => "enable_restart_at"} %>
+      </div>
+
+      <div class="field restart_at">
+        <%= f.label :restart_at, "Restart at" %><br>
+        <%= f.datetime_select :restart_at, {:include_blank => true, :select => DateTime.now}, {class: 'datetime-form-control form-inline'} %>
+        <button type="button" id="set_today_btn" class="btn btn-default" autocomplete="off">
+          Set to Today
+        </button>
+      </div>
+
       <div class="actions">
         <%= f.submit class: "btn btn-primary" %>
       </div>

--- a/app/views/kiosks/index.html.erb
+++ b/app/views/kiosks/index.html.erb
@@ -22,9 +22,9 @@
           <td><%= link_to kiosk.name, kiosk %></td>
           <td>
             <% if kiosk.restart_at_active == true %>
-              <span class="label label-info">Active</span>
+              <span class="label label-danger">Pending</span>
             <% else %>
-              <span class="label label-default">Inactive/Expired</span>
+              <span class="label label-default">Restarted</span>
             <% end %>
           </td>
           <td><%= kiosk.restart_at %></td>

--- a/app/views/kiosks/index.html.erb
+++ b/app/views/kiosks/index.html.erb
@@ -10,6 +10,8 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Restart Status</th>
+        <th>Restart Date/time</th>
         <th colspan="3"></th>
       </tr>
     </thead>
@@ -18,6 +20,14 @@
       <% @kiosks.each do |kiosk| %>
         <tr>
           <td><%= link_to kiosk.name, kiosk %></td>
+          <td>
+            <% if kiosk.restart_at_active == true %>
+              <span class="label label-info">Active</span>
+            <% else %>
+              <span class="label label-default">Inactive/Expired</span>
+            <% end %>
+          </td>
+          <td><%= kiosk.restart_at %></td>
           <td><%= link_to 'Show', kiosk_show_path(id: kiosk.name) %></td>
           <td><%= link_to 'Edit', edit_kiosk_path(kiosk) %></td>
           <td><%= link_to 'Destroy', kiosk, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/kiosks/show.html.erb
+++ b/app/views/kiosks/show.html.erb
@@ -24,6 +24,16 @@
       </tr>
       <tr>
         <th scope="row">
+          <strong>Restart at:</strong>
+        </th>
+        <td>
+          <p>
+          <%= @kiosk.restart_at %>
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">
           <strong>Layout Name:</strong>
         </th>
         <td>

--- a/app/views/kiosks/show.html.erb
+++ b/app/views/kiosks/show.html.erb
@@ -29,9 +29,9 @@
         <td>
           <p>
             <% if @kiosk.restart_at_active == true %>
-              <span class="label label-info">Active</span>
+              <span class="label label-danger">Pending</span>
             <% else %>
-              <span class="label label-default">Inactive/Expired</span>
+              <span class="label label-default">Restarted</span>
             <% end %>
           </p>
         </td>

--- a/app/views/kiosks/show.html.erb
+++ b/app/views/kiosks/show.html.erb
@@ -24,6 +24,20 @@
       </tr>
       <tr>
         <th scope="row">
+          <strong>Restart status</strong>
+        </th>
+        <td>
+          <p>
+            <% if @kiosk.restart_at_active == true %>
+              <span class="label label-info">Active</span>
+            <% else %>
+              <span class="label label-default">Inactive/Expired</span>
+            <% end %>
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row">
           <strong>Restart at:</strong>
         </th>
         <td>

--- a/db/migrate/20180125230000_add_restart_at_to_kiosks.rb
+++ b/db/migrate/20180125230000_add_restart_at_to_kiosks.rb
@@ -1,0 +1,5 @@
+class AddRestartAtToKiosks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :kiosks, :restart_at, :datetime
+  end
+end

--- a/db/migrate/20180127115141_add_restart_at_active_to_kiosks.rb
+++ b/db/migrate/20180127115141_add_restart_at_active_to_kiosks.rb
@@ -1,0 +1,5 @@
+class AddRestartAtActiveToKiosks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :kiosks, :restart_at_active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180124180535) do
+ActiveRecord::Schema.define(version: 20180127115141) do
 
   create_table "collections", force: :cascade do |t|
     t.string   "name"
@@ -41,9 +41,11 @@ ActiveRecord::Schema.define(version: 20180124180535) do
 
   create_table "kiosks", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
     t.integer  "kiosk_layout_id"
+    t.datetime "restart_at"
+    t.boolean  "restart_at_active"
     t.index ["kiosk_layout_id"], name: "index_kiosks_on_kiosk_layout_id"
   end
 

--- a/spec/javascripts/react/.factories.js
+++ b/spec/javascripts/react/.factories.js
@@ -46,6 +46,7 @@ export const kiosk = {
   },
   title: "",
   slides: [],
+  restart_kiosk: "",
   starting_slide_index: 0,
   errors: []
 };

--- a/spec/javascripts/react/actions/circActions.test.js
+++ b/spec/javascripts/react/actions/circActions.test.js
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import {ADD_ERROR, SET_SLIDES} from '../../../../app/assets/javascripts/react/actions/kioskActions';
+import {ADD_ERROR, SET_SLIDES, SET_RESTART_KIOSK} from '../../../../app/assets/javascripts/react/actions/kioskActions';
 import {FETCHING_ROOMS_AVAILABLE_COUNT, FETCHED_ROOMS_AVAILABLE_COUNT, SET_ROOMS_AVAILABLE_COUNT} from '../../../../app/assets/javascripts/react/actions/circActions';
 import * as actionCreator from '../../../../app/assets/javascripts/react/actions/circActions';
 import * as factories from '../.factories';

--- a/spec/javascripts/react/actions/kioskActions.test.js
+++ b/spec/javascripts/react/actions/kioskActions.test.js
@@ -29,6 +29,15 @@ describe('Action::Kiosk', () => {
     })
   });
 
+  describe('#setRestartKiosk()', () => {
+    it('matches the snapshot', () => {
+      // execute
+      let action = actionCreator.setRestartKiosk([factories.kiosk.restart_kiosk]);
+      // verify
+      expect(action).toMatchSnapshot();
+    })
+  });
+
   describe('#setTitle()', () => {
     it('matches the snapshot', () => {
       // execute

--- a/spec/javascripts/react/actions/touchActions.test.js
+++ b/spec/javascripts/react/actions/touchActions.test.js
@@ -1,8 +1,8 @@
 import nock from 'nock';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import {ADD_ERROR, SET_SLIDES} from '../../../../app/assets/javascripts/react/actions/kioskActions';
-import {FETCHING_SLIDES, FETCHED_SLIDES, FETCHING_HOURS, FETCHED_HOURS, SET_HOURS} from '../../../../app/assets/javascripts/react/actions/touchActions';
+import {ADD_ERROR, SET_SLIDES, SET_RESTART_KIOSK} from '../../../../app/assets/javascripts/react/actions/kioskActions';
+import {FETCHING_SLIDES, FETCHED_SLIDES, FETCHING_RESTART_KIOSK, FETCHED_RESTART_KIOSK, FETCHING_HOURS, FETCHED_HOURS, SET_HOURS} from '../../../../app/assets/javascripts/react/actions/touchActions';
 import * as actionCreator from '../../../../app/assets/javascripts/react/actions/touchActions';
 import * as factories from '../.factories';
 

--- a/spec/javascripts/react/components/DonorKiosk.test.js
+++ b/spec/javascripts/react/components/DonorKiosk.test.js
@@ -3,7 +3,7 @@ import * as factories from '../.factories';
 
 describe('Donor Kiosk', () => {
   it('maps state to props', () => {
-    expect(mapStateToProps({kiosk: {slides: factories.slides, title: factories.slide.title }})).toMatchSnapshot();
+    expect(mapStateToProps({kiosk: {slides: factories.slides, title: factories.slide.title, restart_kiosk: factories.kiosk.restart_kiosk }})).toMatchSnapshot();
   });
 
   it('maps dispatch to props', () => {

--- a/spec/javascripts/react/components/presentational/Circulation/Kiosk.test.js
+++ b/spec/javascripts/react/components/presentational/Circulation/Kiosk.test.js
@@ -8,8 +8,10 @@ const setup = () => {
     factories.initial_state,
     {
       slides: factories.slides,
+      restart_kiosk: factories.kiosk.restart_kiosk,
       is_fetching_slides: false,
       show_nav: false,
+      fetchRestartKiosk: jest.fn(),
       fetchSlides: jest.fn(),
       scrollToSlide: jest.fn(),
       rooms_available_count: jest.fn(),

--- a/spec/javascripts/react/components/presentational/Donor/Kiosk.test.js
+++ b/spec/javascripts/react/components/presentational/Donor/Kiosk.test.js
@@ -8,11 +8,13 @@ const setup = () => {
     factories.initial_state,
     {
       slides: factories.slides,
+      restart_kiosk: factories.kiosk.restart_kiosk,
       setModalVisibility: jest.fn(),
       setModalRootComponent: jest.fn(),
       google_analytics: jest.fn(),
       title: "Bogus actual text title",
       setTitle: jest.fn(),
+      fetchRestartKiosk: jest.fn(),
       is_modal_visible: false,
     });
   const enzyme_wrapper = shallow(<Kiosk {...props}/>);

--- a/spec/javascripts/react/components/presentational/Touch/Kiosk.test.js
+++ b/spec/javascripts/react/components/presentational/Touch/Kiosk.test.js
@@ -8,6 +8,7 @@ const setup = () => {
     factories.initial_state,
     {
       slides: factories.slides,
+      restart_kiosk: factories.kiosk.restart_kiosk,
       is_fetching_slides: false,
       show_nav: true,
       maps: [],
@@ -15,6 +16,7 @@ const setup = () => {
       api: {},
       google_analytics: jest.fn(),
       fetchSlides: jest.fn(),
+      fetchRestartKiosk: jest.fn(),
       setModalVisibility: jest.fn(),
       setModalRootComponent: jest.fn(),
       scrollToSlide: jest.fn(),

--- a/spec/javascripts/react/reducers/kioskReducer.test.js
+++ b/spec/javascripts/react/reducers/kioskReducer.test.js
@@ -23,6 +23,11 @@ describe('Reducers::Kiosk', () => {
       expect(reducerCreator(empty_state, actionCreator.setSlides(factories.slides))).toMatchSnapshot();
     })
   });
+  describe('setRestartKiosk action', () => {
+    it('matches the snapshot', () => {
+      expect(reducerCreator(empty_state, actionCreator.setRestartKiosk(factories.kiosk.restart_kiosk))).toMatchSnapshot();
+    })
+  });
   describe('scrollToSlide action', () => {
     it('matches the snapshot', () => {
       expect(reducerCreator(empty_state, actionCreator.scrollToSlide(1))).toMatchSnapshot();

--- a/spec/models/kiosk_spec.rb
+++ b/spec/models/kiosk_spec.rb
@@ -9,4 +9,8 @@ RSpec.describe Kiosk, type: :model do
     kiosk = Kiosk.new(name: nil, kiosk_layout_id: nil)
     expect(kiosk).to_not be_valid
   end
+  it "is not valid with a restart_at datetime in the past" do
+    kiosk = Kiosk.new(name: "test", kiosk_layout_id: test_layout.id, restart_at: DateTime.yesterday)
+    expect(kiosk).to_not be_valid
+  end
 end


### PR DESCRIPTION
fixes #171 

- Added properties `restart_at` and `restart_at_active` to `Kiosk` model to support the restarting mechanism
- Implemented `fetchRestartKiosk` action to send a request to the server (every 1 minute) and get the `restart_kiosk` status (`true|false`). If `restart_kiosk` is `true`, then do a page refresh from the browser where the kiosk is being displayed.
- The `kiosk` controller takes care of setting the appropriate `restart_kiosk` flag using the `reload_kiosk?` method. 
- `reload_kiosk?` returns `true` if the `restart_at_active` is `true` and `restart_at < now`  
- If `reload_kiosk?` returns `true`, then (step 1) set `restart_at_active` to `false` (to prevent an infinite loop) and (step 2) return `kiosk_restart = true` back to the client, which would be responsible of performing a full browser refresh.  

- **Edit kiosk**
![image](https://user-images.githubusercontent.com/3486120/35532375-e1b7430a-04ee-11e8-81a5-086cbd2ebc37.png)

- **View single kiosk info**
![image](https://user-images.githubusercontent.com/3486120/35580926-3e4a895a-059f-11e8-867a-2a4f6b8f036a.png)


- **View all kiosks**
![image](https://user-images.githubusercontent.com/3486120/35580943-47fb6c9e-059f-11e8-88be-3222f8f90f5b.png)

