### PR TITLE
updated reload_kiosk method to allow a grace period for all clients

### DIFF
--- a/app/assets/javascripts/react/components/presentational/Circulation/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Circulation/Kiosk.js
@@ -16,7 +16,6 @@ class Kiosk extends Component {
     this._fetchRestartKioskTimeout();
     this.props.fetchHours(this.props.api.hours, [now]);
     this.props.fetchSlides(this.props.url);
-    this.props.fetchRestartKiosk(this.props.url);
   }
 
   /**

--- a/app/assets/javascripts/react/components/presentational/Donor/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Donor/Kiosk.js
@@ -10,7 +10,6 @@ class Kiosk extends Component {
    */
   componentDidMount() {
     this._fetchRestartKioskTimeout();
-    this.props.fetchRestartKiosk(this.props.url);
   }
 
   /**

--- a/app/assets/javascripts/react/components/presentational/Touch/Kiosk.js
+++ b/app/assets/javascripts/react/components/presentational/Touch/Kiosk.js
@@ -16,7 +16,6 @@ class Kiosk extends Component {
     this._fetchRestartKioskTimeout();
     this.props.fetchHours(this.props.api.hours, [now]);
     this.props.fetchSlides(this.props.url);
-    this.props.fetchRestartKiosk(this.props.url);
   }
 
   /**

--- a/app/controllers/kiosk_controller.rb
+++ b/app/controllers/kiosk_controller.rb
@@ -22,7 +22,7 @@ class KioskController < ApplicationController
 
   def reload_kiosk?(kiosk)
     return false if kiosk.restart_at.nil? || kiosk.restart_at_active.nil?
-    kiosk.restart_at_active && kiosk.restart_at < DateTime.now && kiosk.restart_at > 1.minutes.ago
+    kiosk.should_restart?
   end
 
   def set_kiosk_params

--- a/app/controllers/kiosk_controller.rb
+++ b/app/controllers/kiosk_controller.rb
@@ -10,10 +10,8 @@ class KioskController < ApplicationController
     @kiosk = Kiosk.find_by(name: params[:id])
     @restart_kiosk = false.to_s
     if reload_kiosk?(@kiosk)
-      if @kiosk.update_attribute(:restart_at_active, false)
-        @restart_kiosk = true.to_s
-        puts "restarting #{@kiosk.name} kiosk"
-      end
+      @restart_kiosk = true.to_s
+      puts "restarting #{@kiosk.name} kiosk"
     end
 
     # get only slides that have current date ranges, given a time (i.e now, Time.zone.parse("20160503050000"), etc)
@@ -24,7 +22,7 @@ class KioskController < ApplicationController
 
   def reload_kiosk?(kiosk)
     return false if kiosk.restart_at.nil? || kiosk.restart_at_active.nil?
-    kiosk.restart_at_active && kiosk.restart_at < DateTime.now
+    kiosk.restart_at_active && kiosk.restart_at < DateTime.now && kiosk.restart_at > 1.minutes.ago
   end
 
   def set_kiosk_params

--- a/app/models/kiosk.rb
+++ b/app/models/kiosk.rb
@@ -10,4 +10,12 @@ class Kiosk < ApplicationRecord
       errors.add(:restart_at, "(#{restart_at}) can't be in the past, please select a date in the future, or click 'Clear' to remove the date.")
     end
   end
+
+  def should_restart?
+    restart_at_active && restart_at < DateTime.now && restart_at > 1.minutes.ago
+  end
+
+  def is_restart_pending?
+    restart_at_active && (restart_at > DateTime.now || restart_at > 1.minutes.ago)
+  end
 end

--- a/app/views/kiosks/index.html.erb
+++ b/app/views/kiosks/index.html.erb
@@ -9,33 +9,37 @@
   <%= form_tag edit_multiple_kiosks_path, method: :get do %>
     <table class="table table-striped">
       <thead>
-        <tr>
-          <th><input type="checkbox" name="check_all" id="check_all" value=""></th>
-          <th>Name</th>
-          <th>Restart Status</th>
-          <th>Restart Date/time</th>
-          <th colspan="3"></th>
-        </tr>
+      <tr>
+        <th><input type="checkbox" name="check_all" id="check_all" value=""></th>
+        <th>Name</th>
+        <th>Restart Status</th>
+        <th>Restart Date/time</th>
+        <th colspan="3"></th>
+      </tr>
       </thead>
 
       <tbody>
-        <% @kiosks.each do |kiosk| %>
-          <tr>
-            <td><%= check_box_tag "kiosk_ids[]", kiosk.id, false, class: "check_kiosk" %></td>
-            <td><%= link_to kiosk.name, kiosk %></td>
-            <td>
-              <% if kiosk.restart_at_active == true %>
+      <% @kiosks.each do |kiosk| %>
+        <tr>
+          <td><%= check_box_tag "kiosk_ids[]", kiosk.id, false, class: "check_kiosk" %></td>
+          <td><%= link_to kiosk.name, kiosk %></td>
+          <td>
+            <% if kiosk.restart_at_active == true %>
+              <% if kiosk.restart_at > DateTime.now || kiosk.restart_at > 1.minutes.ago %>
                 <span class="label label-danger">Pending</span>
               <% else %>
                 <span class="label label-default">Restarted</span>
               <% end %>
-            </td>
-            <td><%= kiosk.restart_at %></td>
-            <td><%= link_to 'Show', kiosk_show_path(id: kiosk.name) %></td>
-            <td><%= link_to 'Edit', edit_kiosk_path(kiosk) %></td>
-            <td><%= link_to 'Destroy', kiosk, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-          </tr>
-        <% end %>
+            <% else %>
+              <span class="label label-default">Restarted</span>
+            <% end %>
+          </td>
+          <td><%= kiosk.restart_at %></td>
+          <td><%= link_to 'Show', kiosk_show_path(id: kiosk.name) %></td>
+          <td><%= link_to 'Edit', edit_kiosk_path(kiosk) %></td>
+          <td><%= link_to 'Destroy', kiosk, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        </tr>
+      <% end %>
       </tbody>
       <tfoot>
       <tr>
@@ -52,4 +56,3 @@
 
 <%= link_to 'New Kiosk', new_kiosk_path, class: "btn btn-primary" %>
 <%= link_to 'Admin Panel', admin_index_path, class: "btn btn-default" %>
-

--- a/app/views/kiosks/index.html.erb
+++ b/app/views/kiosks/index.html.erb
@@ -25,7 +25,7 @@
             <td><%= link_to kiosk.name, kiosk %></td>
             <td>
               <% if kiosk.restart_at_active == true %>
-                <% if kiosk.restart_at > DateTime.now || kiosk.restart_at > 1.minutes.ago %>
+                <% if kiosk.is_restart_pending? %>
                   <span class="label label-danger">Pending</span>
                 <% else %>
                   <span class="label label-default">Restarted</span>

--- a/app/views/kiosks/index.html.erb
+++ b/app/views/kiosks/index.html.erb
@@ -9,37 +9,37 @@
   <%= form_tag edit_multiple_kiosks_path, method: :get do %>
     <table class="table table-striped">
       <thead>
-      <tr>
-        <th><input type="checkbox" name="check_all" id="check_all" value=""></th>
-        <th>Name</th>
-        <th>Restart Status</th>
-        <th>Restart Date/time</th>
-        <th colspan="3"></th>
-      </tr>
+        <tr>
+          <th><input type="checkbox" name="check_all" id="check_all" value=""></th>
+          <th>Name</th>
+          <th>Restart Status</th>
+          <th>Restart Date/time</th>
+          <th colspan="3"></th>
+        </tr>
       </thead>
 
       <tbody>
-      <% @kiosks.each do |kiosk| %>
-        <tr>
-          <td><%= check_box_tag "kiosk_ids[]", kiosk.id, false, class: "check_kiosk" %></td>
-          <td><%= link_to kiosk.name, kiosk %></td>
-          <td>
-            <% if kiosk.restart_at_active == true %>
-              <% if kiosk.restart_at > DateTime.now || kiosk.restart_at > 1.minutes.ago %>
-                <span class="label label-danger">Pending</span>
+        <% @kiosks.each do |kiosk| %>
+          <tr>
+            <td><%= check_box_tag "kiosk_ids[]", kiosk.id, false, class: "check_kiosk" %></td>
+            <td><%= link_to kiosk.name, kiosk %></td>
+            <td>
+              <% if kiosk.restart_at_active == true %>
+                <% if kiosk.restart_at > DateTime.now || kiosk.restart_at > 1.minutes.ago %>
+                  <span class="label label-danger">Pending</span>
+                <% else %>
+                  <span class="label label-default">Restarted</span>
+                <% end %>
               <% else %>
                 <span class="label label-default">Restarted</span>
               <% end %>
-            <% else %>
-              <span class="label label-default">Restarted</span>
-            <% end %>
-          </td>
-          <td><%= kiosk.restart_at %></td>
-          <td><%= link_to 'Show', kiosk_show_path(id: kiosk.name) %></td>
-          <td><%= link_to 'Edit', edit_kiosk_path(kiosk) %></td>
-          <td><%= link_to 'Destroy', kiosk, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-        </tr>
-      <% end %>
+            </td>
+            <td><%= kiosk.restart_at %></td>
+            <td><%= link_to 'Show', kiosk_show_path(id: kiosk.name) %></td>
+            <td><%= link_to 'Edit', edit_kiosk_path(kiosk) %></td>
+            <td><%= link_to 'Destroy', kiosk, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          </tr>
+        <% end %>
       </tbody>
       <tfoot>
       <tr>

--- a/spec/models/kiosk_spec.rb
+++ b/spec/models/kiosk_spec.rb
@@ -13,4 +13,42 @@ RSpec.describe Kiosk, type: :model do
     kiosk = Kiosk.new(name: "test", kiosk_layout_id: test_layout.id, restart_at: DateTime.yesterday)
     expect(kiosk).to_not be_valid
   end
+
+  context "#should_restart?" do
+    let(:restart_at) { Time.zone.parse("2018-01-17 07:30:00") }
+    let(:kiosk) { Kiosk.new(name: "test", kiosk_layout_id: test_layout.id, restart_at: restart_at, restart_at_active: true) }
+
+    it "should restart now" do
+      now = Time.zone.parse("2018-01-17 07:30:10")
+      allow(DateTime).to receive(:now) { now }
+      allow(Time).to receive(:now) { now }
+      expect(kiosk.should_restart?).to be_truthy
+    end
+
+    it "should not restart now" do
+      now = Time.zone.parse("2018-01-17 07:29:10")
+      allow(DateTime).to receive(:now) { now }
+      allow(Time).to receive(:now) { now }
+      expect(kiosk.should_restart?).to be_falsey
+    end
+  end
+
+  context "#is_restart_pending?" do
+    let(:restart_at) { Time.zone.parse("2018-01-17 07:30:00") }
+    let(:kiosk) { Kiosk.new(name: "test", kiosk_layout_id: test_layout.id, restart_at: restart_at, restart_at_active: true) }
+
+    it "restart is pending" do
+      now = Time.zone.parse("2018-01-17 06:30:10")
+      allow(DateTime).to receive(:now) { now }
+      allow(Time).to receive(:now) { now }
+      expect(kiosk.is_restart_pending?).to be_truthy
+    end
+
+    it "kiosk is restarted" do
+      now = Time.zone.parse("2018-01-17 08:30:00")
+      allow(DateTime).to receive(:now) { now }
+      allow(Time).to receive(:now) { now }
+      expect(kiosk.is_restart_pending?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
fixes #176 

After discussing issue #176 with @revgum Josh had the idea of enhancing feature https://github.com/osulp/kiosks/pull/173 by setting a grace period (1 min) in order to allow any client to restart itself during this timeframe. See diagram below:

![image](https://user-images.githubusercontent.com/3486120/35700730-a99ad980-0748-11e8-9a6d-37b65e87ca9f.png)

- This PR implements the grace period (1 minute past restart_at) in `reload_kiosk?`
- This update also adds a 1-minute delay to fetch `restart_kiosk` when the kiosk is mounted on start. This change allows the grace period to get closed first before sending the next request to fetch `restart_kiosk`
