### PR TITLE
updated migrate errors to ignore migrations related to paperclip

### DIFF
--- a/db/migrate/20161208192704_add_attachment_image_to_slides.rb
+++ b/db/migrate/20161208192704_add_attachment_image_to_slides.rb
@@ -1,7 +1,7 @@
-class AddAttachmentImageToSlides < ActiveRecord::Migration
+class AddAttachmentImageToSlides < ActiveRecord::Migration[5.1]
   def self.up
     change_table :slides do |t|
-      t.attachment :image
+      # t.attachment :image
     end
   end
 

--- a/db/migrate/20170327215219_paperclip_to_carrierwave.rb
+++ b/db/migrate/20170327215219_paperclip_to_carrierwave.rb
@@ -1,5 +1,5 @@
 class PaperclipToCarrierwave < ActiveRecord::Migration[5.0]
   def change
-    rename_column :slides, :image_file_name, :image
+    # rename_column :slides, :image_file_name, :image
   end
 end


### PR DESCRIPTION
commenting out migration actions related to paperclip since it was removed in https://github.com/osulp/kiosks/pull/167

paperclip was replaced with carrierwave in https://github.com/osulp/kiosks/pull/122