### PR TITLE
Feature/update labels

### DIFF
--- a/app/assets/javascripts/react/components/presentational/Interactive/Header.js
+++ b/app/assets/javascripts/react/components/presentational/Interactive/Header.js
@@ -39,7 +39,7 @@ class Header extends Component {
                         </button>
                         <img className={`logo ${tapped_enough ? 'is_active' : ''}`} src="/images/osulogo.svg" onClick={this.props._didTap} />
                     </div>
-                    <p className="hours navbar-text">{this._hoursToday()}</p>
+                    <p className="hours navbar-text">Valley Library Hours Today: {this._hoursToday()}</p>
                     <div className="nav navbar-nav navbar-right main-menu-header">
                         <button className="btn btn-default main-menu hidden" onClick={this.props.mainMenuClicked}>
                             <span className={`glyphicon glyphicon-menu-hamburger`}></span>

--- a/app/assets/javascripts/react/components/presentational/Interactive/Menu.js
+++ b/app/assets/javascripts/react/components/presentational/Interactive/Menu.js
@@ -37,10 +37,10 @@ class Menu extends Component {
             <li className="show-search-primo" onClick={this.props.searchPrimoClicked}>
                 <a className={`btn btn-navbar btn-default ${(this.props.selectedMenuItem == "primo" ? "menu-item-selected" : "")}`}>
                     <img className={"menu-item-icon"} src={"/images/search.svg"} />
-                    <span className={"menu-item-text"}>Search</span>
+                    <span className={"menu-item-text"}>1Search</span>
                 </a>
             </li>
-            <li className="show-classroom-schedule" onClick={this.props.classroomScheduleClicked}>
+            <li className="show-classroom-schedule hidden" onClick={this.props.classroomScheduleClicked}>
                 <a className={`btn btn-navbar btn-default ${(this.props.selectedMenuItem == "schedule" ? "menu-item-selected" : "")}`}>
                     <img className={"menu-item-icon"} src={"/images/calendar-alt.svg"} />
                     <span className={"menu-item-text"}>Classrooms</span>


### PR DESCRIPTION
fixes #227 
- updates the label used in the header for today's hours (interactive touch layout)
- updates the label used for the search menu item (interactive touch layout)
- hides the calendar menu item in the interactive touch layout (we can bring it back until we figure out a way to integrate the new calendar as a data source for this section)