### PR TITLE
updated mysql2 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'rubocop'
 gem 'rubycas-client', git: 'https://github.com/osulp/rubycas-client'
 gem 'rubycas-client-rails', git: 'https://github.com/osulp/rubycas-client-rails'
 
-gem 'mysql2'
+gem 'mysql2', '0.4.5'
 gem 'nokogiri'
 
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    mysql2 (0.5.2)
+    mysql2 (0.4.5)
     nested_form (0.3.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -397,7 +397,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   listen (~> 3.0.5)
-  mysql2
+  mysql2 (= 0.4.5)
   nokogiri
   poltergeist
   pry


### PR DESCRIPTION
fixes:
```
Puma starting in single mode...
* Version 3.8.2 (ruby 2.5.1-p57), codename: Sassy Salamander
* Min threads: 5, max threads: 5
* Environment: staging
! Unable to load application: Gem::LoadError: Specified 'mysql2' for database adapter, but the gem is not loaded. Add `gem 'mysql2'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).
```