### PR TITLE
upgrade node version in deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -19,7 +19,7 @@ set :rbenv_ruby, '2.3.3'
 # The server must have nvm installed at the user level, and to have yarn installed globally as an npm package
 # for the node version specified here.
 set :nvm_type, :user
-set :nvm_node, 'v6.9.1'
+set :nvm_node, 'v6.11.5'
 set :nvm_map_bins, %w{node npm yarn}
 
 # Default value for :format is :airbrussh.


### PR DESCRIPTION
update `nvm_node` version to a recommended version to prevent error during deploy:
```
error webpack-dev-server@3.1.14: The engine "node" is incompatible with this module. Expected version ">= 6.11.5".

error Found incompatible module
```
related update: https://github.com/osulp/kiosks/pull/257