### PR TITLE
Makes slide know what kiosk its being rendered on.

### DIFF
--- a/app/assets/javascripts/react/components/presentational/shared/SlideGallery.js
+++ b/app/assets/javascripts/react/components/presentational/shared/SlideGallery.js
@@ -23,7 +23,7 @@ class SlideGallery extends Component {
   itemPath(item) {
     let path = '';
 
-    switch(item.kiosk[0].name) {
+    switch(item.current_kiosk) {
       case 'tall':
         path = item.xtall;
         break;

--- a/app/views/kiosk/show.json.jbuilder
+++ b/app/views/kiosk/show.json.jbuilder
@@ -12,6 +12,7 @@ json.slides @slides do |slide|
   json.title slide.title
   json.caption slide.caption
   json.slide_type slide.slide_type.name
+  json.current_kiosk @kiosk.name
   json.kiosk do
     json.array!(slide.kiosks) do |kiosk|
       json.name kiosk.name


### PR DESCRIPTION
This lets a slide know what kiosk it is currently being rendered on. This can ensure that the slide can be rendered in a specific size depending on its current kiosk. This allows for shared collections over multiple kiosks to work with the possibility that the kiosks might have different rendering expectations. 