### PR TITLE
upgrade fstream package to address security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@rails/webpacker": "^4.0",
+    "fstream": "^1.0.12",
     "jquery": "^3.4.0",
     "jquery-ui": "^1.12.1",
     "masonry-layout": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3966,6 +3966,16 @@ fstream@^1.0.0, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"


### PR DESCRIPTION
Upgrade fstream to version 1.0.12 or later.
`yarn upgrade fstream@^1.0.12` to address security alert WS-2019-0100