### PR TITLE
updates for cover-flow layout

### DIFF
--- a/app/javascript/react/components/presentational/DonorCoverflow/Kiosk.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/Kiosk.js
@@ -168,7 +168,7 @@ const Kiosk = props => {
                 }}
               >
                 <img
-                  src={slide.original}
+                  src={slide.large}
                   style={{
                     display: "block",
                     width: "auto",

--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -50,7 +50,7 @@ const LargeSlide = props => {
   }
 
   const slideClicked = i => {
-    let close_zoom_timeout = 5000
+    let close_zoom_timeout = 30000
     if (slideZoomedIndex === i) {
       clearTimeout(zoomTimeout)
       close_zoom_timeout = 150

--- a/app/views/kiosk/show.json.jbuilder
+++ b/app/views/kiosk/show.json.jbuilder
@@ -6,6 +6,7 @@ json.cache! ['v1', @kiosk], expires_in: Rails.env.development? ? 1.second : 24.h
     json.original slide.image.url
     json.thumbnail slide.image.url(:thumb)
     json.xlarge slide.image.url(:xlarge)
+    json.large slide.image.url(:large)
     json.xtall slide.image.url(:xtall)
     json.av_media slide.video_url
     json.subtitle_en slide.subtitles[0].present? ? slide.subtitles[0].url : ''
@@ -34,6 +35,7 @@ json.cache! ['v1', @kiosk], expires_in: Rails.env.development? ? 1.second : 24.h
         json.original slide.collection.primary_slide&.image&.url
         json.thumbnail slide.collection.primary_slide&.image&.url(:thumb)
         json.xlarge slide.collection.primary_slide&.image&.url(:xlarge)
+        json.large slide.collection.primary_slide&.image&.url(:large)
       end
       json.slides do
         json.array!(slide.collection.slides) do |collection_slide|
@@ -41,6 +43,7 @@ json.cache! ['v1', @kiosk], expires_in: Rails.env.development? ? 1.second : 24.h
           json.original collection_slide.image.url
           json.thumbnail collection_slide.image.url(:thumb)
           json.xlarge collection_slide.image.url(:xlarge)
+          json.large collection_slide.image.url(:large)
         end
       end
     end


### PR DESCRIPTION
Coverflow updates:

- update cover-flow layout to use a large derivative [resize_to_limit: [600, 600]](https://github.com/osulp/kiosks/blob/master/app/uploaders/image_uploader.rb#L49-L51) of images instead of the original size
- update zoom in/out timeout to 30 seconds (instead of 5) when clicking images in the detail page