### PR TITLE
add touch method to slides model for cache refresh

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,7 @@
 class Collection < ApplicationRecord
   # attr_accessor :slides_attributes
   has_many :slides, inverse_of: :collection, dependent: :destroy
-  belongs_to :primary_slide, class_name: 'Slide', optional: true
+  belongs_to :primary_slide, class_name: 'Slide', optional: true, touch: true
   validates :name, presence: true
   accepts_nested_attributes_for :slides, reject_if: proc { |attributes| attributes[:title].blank? }, allow_destroy: true
 end

--- a/app/models/kiosk.rb
+++ b/app/models/kiosk.rb
@@ -2,7 +2,7 @@
 
 # Kiosk records relate to individual screens
 class Kiosk < ApplicationRecord
-  belongs_to :kiosk_layout
+  belongs_to :kiosk_layout, touch: true
   has_many :kiosk_slides, dependent: :destroy
   has_many :slides, through: :kiosk_slides
   validates :name, presence: true

--- a/app/models/kiosk_slide.rb
+++ b/app/models/kiosk_slide.rb
@@ -2,6 +2,6 @@
 
 # Relationship between a slide and a kiosk
 class KioskSlide < ApplicationRecord
-  belongs_to :kiosk
-  belongs_to :slide
+  belongs_to :kiosk, touch: true
+  belongs_to :slide, touch: true
 end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -2,6 +2,7 @@
 
 # Slides are the primary representation of the media on display at the various kiosks
 class Slide < ApplicationRecord
+  after_save :touch_kiosks
   include Rails.application.routes.url_helpers
   attr_accessor :image
   attr_accessor :video
@@ -39,5 +40,9 @@ class Slide < ApplicationRecord
 
   def subtitle_filename(index)
     File.basename subtitles[index].url if subtitles[index].present?
+  end
+
+  def touch_kiosks
+    kiosks.each { |k| k.touch }
   end
 end

--- a/app/models/slide.rb
+++ b/app/models/slide.rb
@@ -43,6 +43,6 @@ class Slide < ApplicationRecord
   end
 
   def touch_kiosks
-    kiosks.each { |k| k.touch }
+    kiosks.each(&:touch)
   end
 end


### PR DESCRIPTION
fixes https://github.com/osulp/kiosks/issues/310
related https://github.com/osulp/kiosks/issues/299#issuecomment-472488686

- Since we have a cache for 24 hours in each kiosk display at https://github.com/osulp/kiosks/blob/master/app/views/kiosk/show.json.jbuilder#L3 whenever we tried to add new slides, the update wouldn't take effect until the next day, causing a delay for displaying updated slides
- This updates the kiosk-slide models so that they get refreshed for the cache when adding/updating/deleting slides