### PR TITLE
add small tweaks to navigation and LargeSlide component in DonorCover…

### DIFF
--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -105,7 +105,7 @@ const LargeSlide = props => {
                 }}
               >
                 <img
-                  src={s.original}
+                  src={s.large}
                   style={{
                     width: "100%"
                   }}

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -12,10 +12,9 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <% if user_signed_in? %>
-          <li><%= link_to "Home", root_path %></li>
           <li><%= link_to "Collections", collections_path %></li>
           <li><%= link_to "Slides", slides_path %></li>
-          <li><%= link_to "Kiosks", kiosks_path %></li>
+          <li><%= link_to "Manage Kiosks", kiosks_path %></li>
         <% end %>
       </ul>
       <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
…flow

- Remove `Home` link since it's redundant with "Kiosks" link in the navigation bar
- Use `large` image for LargeSlide component in DonorCoverflow layout