### PR TITLE
Fix large slide timeout

### DIFF
--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -23,12 +23,10 @@ const LargeSlide = props => {
       props.setModalVisibility(false)
       props.setModalRootComponent(undefined)
     }, 180000)
-    console.log("set hide_timeout")
     setHideTimeout(hide_timeout)
     setImageCount(props.slide.collection.slides.length)
     setImagesLoaded(0)
     return () => {
-      console.log("clear hide_timeout")
       clearTimeout(hide_timeout)
       clearTimeout(exiting_timeout)
       clearTimeout(zoomTimeout)

--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -23,12 +23,14 @@ const LargeSlide = props => {
       props.setModalVisibility(false)
       props.setModalRootComponent(undefined)
     }, 180000)
+    console.log("set hide_timeout")
     setHideTimeout(hide_timeout)
     setImageCount(props.slide.collection.slides.length)
     setImagesLoaded(0)
     return () => {
-      clearTimeout(hideTimeout)
-      clearTimeout(exitingTimeout)
+      console.log("clear hide_timeout")
+      clearTimeout(hide_timeout)
+      clearTimeout(exiting_timeout)
       clearTimeout(zoomTimeout)
     }
   }, [])


### PR DESCRIPTION
fixes https://github.com/osulp/kiosks/issues/324
update `clearTimeout` to use `hide_timeout` instead of `hideTimeout`, and similarly with `exiting_timeout`.