### PR TITLE
Set rotating timeout to 30 seconds

### DIFF
--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -10,13 +10,18 @@ const LargeSlide = props => {
   const [imagesLoaded, setImagesLoaded] = useState(-1)
   const [slideZoomedIndex, setSlideZoomedIndex] = useState(-1)
   const [exitingTimeout, setExitingTimeout] = useState(undefined)
+  const [rotatingTimeout, setRotatingTimeout] = useState(undefined)
   const [hideTimeout, setHideTimeout] = useState(undefined)
   const [zoomTimeout, setZoomTimeout] = useState(undefined)
 
   useEffect(() => {
-    const exiting_timeout = setTimeout(() => {
+    const rotating_timeout = setTimeout(() => {
       props.rotateActiveSlides()
+    }, 3000)
+    setRotatingTimeout(rotating_timeout)
+    const exiting_timeout = setTimeout(() => {
       setSlideAnimationClass("slide-exiting")
+      setRotatingTimeout(rotating_timeout)
     }, 179650)
     setExitingTimeout(exiting_timeout)
     const hide_timeout = setTimeout(() => {
@@ -27,6 +32,7 @@ const LargeSlide = props => {
     setImageCount(props.slide.collection.slides.length)
     setImagesLoaded(0)
     return () => {
+      clearTimeout(rotating_timeout)
       clearTimeout(hide_timeout)
       clearTimeout(exiting_timeout)
       clearTimeout(zoomTimeout)

--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -21,7 +21,6 @@ const LargeSlide = props => {
     setRotatingTimeout(rotating_timeout)
     const exiting_timeout = setTimeout(() => {
       setSlideAnimationClass("slide-exiting")
-      setRotatingTimeout(rotating_timeout)
     }, 179650)
     setExitingTimeout(exiting_timeout)
     const hide_timeout = setTimeout(() => {

--- a/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
+++ b/app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js
@@ -17,7 +17,7 @@ const LargeSlide = props => {
   useEffect(() => {
     const rotating_timeout = setTimeout(() => {
       props.rotateActiveSlides()
-    }, 3000)
+    }, 31000)
     setRotatingTimeout(rotating_timeout)
     const exiting_timeout = setTimeout(() => {
       setSlideAnimationClass("slide-exiting")


### PR DESCRIPTION
fixes #327 

This updates app/javascript/react/components/presentational/DonorCoverflow/LargeSlide.js and adds a timeout for rotating slides in the DonorCoverlow layout