### PR TITLE
removes broken flipclock

### DIFF
--- a/app/javascript/react/components/presentational/Circulation/Rooms.js
+++ b/app/javascript/react/components/presentational/Circulation/Rooms.js
@@ -19,7 +19,6 @@ class Rooms extends Component {
   setFlipCounter() {
     let rooms_available = this.props.rooms_available_count
     let rooms_count = rooms_available.length ? rooms_available.length : 0
-    this.clock.setValue(rooms_count)
   }
 
   /**
@@ -46,9 +45,6 @@ class Rooms extends Component {
     let rooms_available = this.props.rooms_available_count
     let rooms_count = rooms_available.length ? rooms_available.length : 0
 
-    this.clock = new FlipClock($(".circ-counter"), rooms_count, {
-      clockFace: "Counter"
-    })
     return (
       <div className="navbar-wrapper">
         <div className="circ-sidebar-title">Study Rooms Available</div>


### PR DESCRIPTION
I did everything I possibly could muster up trying to fix this thing, but for some reason webpack isnt compiling the files proper and its failing to set the global FlipClock variable. So this file cannot find it. This was inaccurate as well though, so maybe disabling it until we find a better solution is the right way to go.