### PR TITLE
Escape title and caption in kiosk/slide JSON output. Add spec.

### DIFF
--- a/app/views/kiosk/show.json.jbuilder
+++ b/app/views/kiosk/show.json.jbuilder
@@ -11,8 +11,8 @@ json.cache! ['v1', @kiosk], expires_in: Rails.env.development? ? 1.second : 24.h
     json.av_media slide.video_url
     json.subtitle_en slide.subtitles[0].present? ? slide.subtitles[0].url : ''
     json.subtitle_es slide.subtitles[1].present? ? slide.subtitles[1].url : ''
-    json.title slide.title
-    json.caption slide.caption
+    json.title html_escape(slide.title)
+    json.caption html_escape(slide.caption)
     json.slide_type slide.slide_type.name
     json.current_kiosk @kiosk.name
     json.slide_length @kiosk.slide_length_ms

--- a/spec/views/kiosks/show.json.jbuilder_spec.rb
+++ b/spec/views/kiosks/show.json.jbuilder_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'views/kiosk/show.json.jbuilder' do
+  let(:slide_type) { create(:slide_type, name: 'test slide type') }
+  let(:collection) { create(:collection, name: 'generic') }
+  let(:slide1) { create(:slide) }
+  let(:slide2) { create(:slide, slide2_attributes) }
+  let(:slide2_attributes) do
+    {
+      title: "title slide 2 with ' apostrophe",
+      caption: 'caption 2',
+      slide_type: slide_type,
+      collection: collection,
+      image: Rack::Test::UploadedFile.new('spec/fixtures/Board_Game_Slide.jpg', 'image/jpg')
+    }
+  end
+
+  before do
+    assign(:slides, [slide1, slide2])
+    assign(:kiosk, create(:kiosk))
+    render template: 'kiosk/show.json.jbuilder', format: :json
+  end
+
+  it 'renders slide json with first slide title' do
+    expect(JSON(rendered)['slides'].first['title']).to eq('title')
+  end
+  it 'renders slide json with second slide title with escaped apostrophe' do
+    expect(JSON(rendered)['slides'].second['title']).to eq('title slide 2 with &#39; apostrophe')
+  end
+end


### PR DESCRIPTION
Fixes #336 
(in my testing it was the just the ' regular apostrophe causing problems, not the curly one also mentioned in 336)

This will also handle newlines correctly, like in Caption since it's a multi-line input field. I couldn't find a way to make the spec output match exactly for that one. But from my local testing the JSON output with newlines is: `"caption":"test caption for slide 3\r\nline 2\r\nline 3\r\nline 4",`