### PR TITLE
replace html br tag with comma

### DIFF
--- a/app/javascript/react/components/presentational/Interactive/Header.js
+++ b/app/javascript/react/components/presentational/Interactive/Header.js
@@ -22,10 +22,15 @@ class Header extends Component {
       return ""
     } else {
       let today = Object.values(this.props.todays_hours)[0]
-      // I'm replacing html br tag with a comma to keep the component clean or in one line. TODO: I think we should
-      // introduce a non-HTML formatted_hours field in the API, and rended it
-      // here. Related work: https://github.com/osulp/API/pull/89
-      return `${today.formatted_hours.trim().replace('<br>',', ')} on ${today.string_date}`
+      let formatted_hours = today.formatted_hours.trim()
+      if (formatted_hours != undefined) {
+        // I'm replacing html br tag with a comma to keep the component clean or in one line. TODO: I think we should
+        // introduce a non-HTML formatted_hours field in the API, and rended it
+        // here. Related work: https://github.com/osulp/API/pull/89
+        formatted_hours = formatted_hours.replace('<br>',', ')
+      }
+
+      return `${formatted_hours} on ${today.string_date}`
     }
   }
 

--- a/app/javascript/react/components/presentational/Interactive/Header.js
+++ b/app/javascript/react/components/presentational/Interactive/Header.js
@@ -22,7 +22,10 @@ class Header extends Component {
       return ""
     } else {
       let today = Object.values(this.props.todays_hours)[0]
-      return `${today.formatted_hours.trim()} on ${today.string_date}`
+      // I'm replacing html br tag with a comma to keep the component clean or in one line. TODO: I think we should
+      // introduce a non-HTML formatted_hours field in the API, and rended it
+      // here. Related work: https://github.com/osulp/API/pull/89
+      return `${today.formatted_hours.trim().replace('<br>',', ')} on ${today.string_date}`
     }
   }
 

--- a/app/javascript/react/components/presentational/Touch/HoursTable.js
+++ b/app/javascript/react/components/presentational/Touch/HoursTable.js
@@ -2,6 +2,9 @@ import React, { Component } from "react"
 import PropTypes from "prop-types"
 import moment from "moment"
 
+// I'm replacing html br tag with a comma to keep the formatted_hours clean or in one line. TODO: I think we should
+// introduce a non-HTML formatted_hours field in the API, and rended it in this
+// table. Related work: https://github.com/osulp/API/pull/89
 class HoursTable extends Component {
   render() {
     let hours = this.props.hours
@@ -28,7 +31,7 @@ class HoursTable extends Component {
                 }
               >
                 <td>{h.string_date}</td>
-                <td>{h.formatted_hours}</td>
+                <td>{h.formatted_hours.replace('<br>',', ')}</td>
                 <td>{h.event_desc}</td>
               </tr>
             )

--- a/app/javascript/react/components/presentational/Touch/HoursTable.js
+++ b/app/javascript/react/components/presentational/Touch/HoursTable.js
@@ -2,9 +2,6 @@ import React, { Component } from "react"
 import PropTypes from "prop-types"
 import moment from "moment"
 
-// I'm replacing html br tag with a comma to keep the formatted_hours clean or in one line. TODO: I think we should
-// introduce a non-HTML formatted_hours field in the API, and rended it in this
-// table. Related work: https://github.com/osulp/API/pull/89
 class HoursTable extends Component {
   render() {
     let hours = this.props.hours
@@ -18,6 +15,13 @@ class HoursTable extends Component {
         </thead>
         <tbody>
           {Object.values(hours).map((h, i) => {
+            let formatted_hours = h.formatted_hours
+            if (formatted_hours != undefined) {
+              // I'm replacing html br tag with a comma to keep the component clean or in one line. TODO: I think we should
+              // introduce a non-HTML formatted_hours field in the API, and rended it
+              // here. Related work: https://github.com/osulp/API/pull/89
+              formatted_hours = formatted_hours.replace('<br>',', ')
+            }
             return (
               <tr
                 key={`hours.${i}`}
@@ -31,7 +35,7 @@ class HoursTable extends Component {
                 }
               >
                 <td>{h.string_date}</td>
-                <td>{h.formatted_hours.replace('<br>',', ')}</td>
+                <td>{formatted_hours}</td>
                 <td>{h.event_desc}</td>
               </tr>
             )


### PR DESCRIPTION
 A `<br>` tag was added to `formatted_hours` in https://github.com/osulp/API/pull/89 to improve readability in the library website.

This PR fixes an issue when rendering raw html coming from the hours API. The update basically replaces the `<br>` with `, ` to render the hours in one line in the `Header` and `HoursTable` components for now. 

I think we should introduce a non-html field in https://github.com/osulp/API that can be used in the kiosks. Another option would be to add logic in the react js components to sanitize and decode html tags coming from the hours API.

current behavior:
![image](https://user-images.githubusercontent.com/3486120/69079988-00e48a00-09f0-11ea-9941-32ca745ce9b8.png)

expected behavior:
![image](https://user-images.githubusercontent.com/3486120/69080059-1d80c200-09f0-11ea-8c9b-003b87fb8bd6.png)
