### PR TITLE
adds initializer and updates the add_field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   if %w[production staging development].include? Rails.env
     def append_info_to_payload(payload)
       super(payload)
-      Rack::Honeycomb.add_field(request.env, 'classname', self.class.name)
+      Honeycomb.add_field(request.env, self.class.name)
     end
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -4,7 +4,6 @@
 
 # Initialize Honeycomb before everything else
 require 'honeycomb-beeline'
-Honeycomb.init
 
 require_relative 'config/environment'
 

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,27 +1,28 @@
 Honeycomb.configure do |config|
-  config.write_key = "YOUR_API_KEY"
-  config.dataset = "rails"
-  config.presend_hook do |fields|
-    if fields["name"] == "redis" && fields.has_key?("redis.command")
-      # remove potential PII from the redis command
-      if fields["redis.command"].respond_to? :split
-        fields["redis.command"] = fields["redis.command"].split.first
-      end
-    end
-    if fields["name"] == "sql.active_record"
-      # remove potential PII from the active record events
-      fields.delete("sql.active_record.binds")
-      fields.delete("sql.active_record.type_casted_binds")
-    end
-  end
+  config.write_key = ENV.fetch('HONEYCOMB_WRITEKEY', 'hereisareallylonglookingkey')
+  config.dataset = ENV.fetch('HONEYCOMB_DATASET', 'kiosks-dev')
+  #config.presend_hook do |fields|
+  #  if fields["name"] == "redis" && fields.has_key?("redis.command")
+  #    # remove potential PII from the redis command
+  #    if fields["redis.command"].respond_to? :split
+  #      fields["redis.command"] = fields["redis.command"].split.first
+  #    end
+  #  end
+  #  if fields["name"] == "sql.active_record"
+  #    # remove potential PII from the active record events
+  #    fields.delete("sql.active_record.binds")
+  #    fields.delete("sql.active_record.type_casted_binds")
+  #  end
+  #end
   config.notification_events = %w[
     sql.active_record
     render_template.action_view
-    render_partial.action_view
     render_collection.action_view
     process_action.action_controller
     send_file.action_controller
     send_data.action_controller
     deliver.action_mailer
   ].freeze
+
+  config.client = Libhoney::NullClient.new if Rails.env.development? || ENV.key?("HONEYCOMB_DEBUG")
 end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,0 +1,27 @@
+Honeycomb.configure do |config|
+  config.write_key = "YOUR_API_KEY"
+  config.dataset = "rails"
+  config.presend_hook do |fields|
+    if fields["name"] == "redis" && fields.has_key?("redis.command")
+      # remove potential PII from the redis command
+      if fields["redis.command"].respond_to? :split
+        fields["redis.command"] = fields["redis.command"].split.first
+      end
+    end
+    if fields["name"] == "sql.active_record"
+      # remove potential PII from the active record events
+      fields.delete("sql.active_record.binds")
+      fields.delete("sql.active_record.type_casted_binds")
+    end
+  end
+  config.notification_events = %w[
+    sql.active_record
+    render_template.action_view
+    render_partial.action_view
+    render_collection.action_view
+    process_action.action_controller
+    send_file.action_controller
+    send_data.action_controller
+    deliver.action_mailer
+  ].freeze
+end


### PR DESCRIPTION
@DeadCatLady @decimalator Im only a honeycomb noob, so im not even sure if this was the thing, but I guess `Honeycomb.init` didnt exist anymore, so when firing up our server locally, we would run into some issues.

Removing the Honeycomb.init would allow the app to proceed but hit another snag in the application controller.

Im assuming since Honeycomb wasnt being initialized, the instance variable wasnt being loaded into the app, so `Honeycomb` model was returning a nil value. 

So in order to get Honeycomb initialized proper in the app, I generated an initializer per their documentation. This allowed the add_field method to work as expected, except it takes 2 variables now instead of 3. So I updated that too. Its working locally now, so I wanted to have you two take a look at this so we could remedy the issue.